### PR TITLE
chore: add tracking link to banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <p>
-    <a href="https://hub.ultralytics.com" target="_blank">
-      <img width="100%" src="https://github.com/ultralytics/assets/raw/main/im/ultralytics-hub.png"></a>
+    <a href="https://ow.ly/9ztL50QGEn9" target="_blank">
+      <img width="100%" src="https://github.com/ultralytics/assets/releases/download/v0.0.0/hub-banner-cloud-training.png"></a>
   </p>
 
 [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [हिन्दी](https://docs.ultralytics.com/hi/) | [العربية](https://docs.ultralytics.com/ar/)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ names:
   # Add more classes as needed
 ```
 
-Upload your zipped dataset to [Ultralytics HUB](https://bit.ly/ultralytics_hub) by logging in, navigating to the 'Datasets' tab, and selecting 'Upload Dataset'. This lets you scan and view your dataset prior to training YOLOv5 or YOLOv8 models.
+Upload your zipped dataset to [Ultralytics HUB](https://ow.ly/9ztL50QGEn9) by logging in, navigating to the 'Datasets' tab, and selecting 'Upload Dataset'. This lets you scan and view your dataset prior to training YOLOv5 or YOLOv8 models.
 
 <p align="center">
   <img width="100%" alt="HUB Dataset Upload" src="https://user-images.githubusercontent.com/26833433/216763338-9a8812c8-a4e5-4362-8102-40dad7818396.png">
@@ -95,7 +95,7 @@ Transition your model to 13 different formats including TensorFlow, ONNX, OpenVI
 
 ## ❓ Have Issues or Questions?
 
-For those just embarking on their [Ultralytics HUB](https://bit.ly/ultralytics_hub) journey, the [Issues](https://github.com/ultralytics/hub/issues) tab is your go-to resource for support. Click the 'New Issue' button and share your thoughts or questions. Our aim is to enhance your experience with invaluable solutions and improvements! 😃
+For those just embarking on their [Ultralytics HUB](https://ow.ly/9ztL50QGEn9) journey, the [Issues](https://github.com/ultralytics/hub/issues) tab is your go-to resource for support. Click the 'New Issue' button and share your thoughts or questions. Our aim is to enhance your experience with invaluable solutions and improvements! 😃
 
 <br>
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 <br>
 
-👋 Hello from the [Ultralytics](https://ultralytics.com/) Team! We've been working hard these last few months to launch [Ultralytics HUB](https://bit.ly/ultralytics_hub), a new web tool for training and deploying all your YOLOv5 and YOLOv8 🚀 models from one spot!
+👋 Hello from the [Ultralytics](https://ultralytics.com/) Team! We've been working hard these last few months to launch [Ultralytics HUB](https://ow.ly/9ztL50QGEn9), a new web tool for training and deploying all your YOLOv5 and YOLOv8 🚀 models from one spot!
 
 We hope that the resources here will help you get the most out of HUB. Please browse the HUB <a href="https://docs.ultralytics.com/">Docs</a> for details, raise an issue on <a href="https://github.com/ultralytics/hub/issues/new/choose">GitHub</a> for support, and join our <a href="https://ultralytics.com/discord">Discord</a> community for questions and discussions!
 
@@ -40,7 +40,7 @@ Ultralytics HUB datasets align with the format used by [YOLOv5](https://github.c
 
 ### Dataset Preparation:
 
-Ensure that the YAML file describing your dataset is placed in the root directory of your dataset, as illustrated below. Once in place, zip the directory for uploading to [Ultralytics HUB](https://hub.ultralytics.com/). The dataset YAML, its directory, and the zip file should all bear the identical name.
+Ensure that the YAML file describing your dataset is placed in the root directory of your dataset, as illustrated below. Once in place, zip the directory for uploading to [Ultralytics HUB](https://ow.ly/9ztL50QGEn9). The dataset YAML, its directory, and the zip file should all bear the identical name.
 
 For instance, with a dataset named 'coco8', as shown in [ultralytics/hub/example_datasets/coco8.zip](./example_datasets/coco8.zip), include a `coco8.yaml` within the `coco8/` directory. Zip this to form `coco8.zip` for upload with the command:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <p>
     <a href="https://ow.ly/9ztL50QGEn9" target="_blank">
-      <img width="100%" src="https://github.com/ultralytics/assets/releases/download/v0.0.0/hub-banner-cloud-training.png"></a>
+      <img width="100%" src="https://github.com/ultralytics/assets/raw/main/im/ultralytics-hub.png"></a>
   </p>
 
 [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [हिन्दी](https://docs.ultralytics.com/hi/) | [العربية](https://docs.ultralytics.com/ar/)


### PR DESCRIPTION
This PR updates the HUB banner to use the new Cloud Training Banner.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refreshed the main banner image on the project README.

### 📊 Key Changes
- Updated the URL link to redirect users to a new destination.
- Replaced the old banner image with a new one titled 'hub-banner-cloud-training.png'.

### 🎯 Purpose & Impact
- The updated link and banner aim to provide users with the latest visual and informational content.
- Potential impact includes a more engaging user experience and up-to-date information about Ultralytics' offerings, specifically highlighting cloud training capabilities. 🌐✨