### PR TITLE
Add HUB links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://hub.ultralytics.com" target="_blank">
+    <a href="https://bit.ly/ultralytics_hub" target="_blank">
       <img width="100%" src="https://github.com/ultralytics/assets/raw/main/im/ultralytics-hub.png"></a>
   </p>
 
@@ -40,7 +40,7 @@ Ultralytics HUB datasets align with the format used by [YOLOv5](https://github.c
 
 ### Dataset Preparation:
 
-Ensure that the YAML file describing your dataset is placed in the root directory of your dataset, as illustrated below. Once in place, zip the directory for uploading to [Ultralytics HUB](https://hub.ultralytics.com/). The dataset YAML, its directory, and the zip file should all bear the identical name.
+Ensure that the YAML file describing your dataset is placed in the root directory of your dataset, as illustrated below. Once in place, zip the directory for uploading to [Ultralytics HUB](https://bit.ly/ultralytics_hub/). The dataset YAML, its directory, and the zip file should all bear the identical name.
 
 For instance, with a dataset named 'coco8', as shown in [ultralytics/hub/example_datasets/coco8.zip](./example_datasets/coco8.zip), include a `coco8.yaml` within the `coco8/` directory. Zip this to form `coco8.zip` for upload with the command:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://hub.ultralytics.com" target="_blank">
+    <a href="https://bit.ly/ultralytics_hub" target="_blank">
       <img width="100%" src="https://github.com/ultralytics/assets/raw/main/im/ultralytics-hub.png"></a>
   </p>
 
@@ -23,7 +23,7 @@ Ultralytics HUB 数据集与 [YOLOv5](https://github.com/ultralytics/yolov5) 和
 
 ### 数据集准备：
 
-确保将描述您的数据集的 YAML 文件放在数据集的根目录下，如下所示。放置好后，将目录压缩以上传到 [Ultralytics HUB](https://hub.ultralytics.com/)。数据集 YAML、其目录和 zip 文件应该全部具有相同的名称。
+确保将描述您的数据集的 YAML 文件放在数据集的根目录下，如下所示。放置好后，将目录压缩以上传到 [Ultralytics HUB](https://bit.ly/ultralytics_hub/)。数据集 YAML、其目录和 zip 文件应该全部具有相同的名称。
 
 例如，对于名为 'coco8' 的数据集，如 [ultralytics/hub/example_datasets/coco8.zip](./example_datasets/coco8.zip) 所示，包含一个 `coco8.yaml` 文件在 `coco8/` 目录中。将其压缩成 `coco8.zip` 以使用以下命令上传：
 

--- a/hub.ipynb
+++ b/hub.ipynb
@@ -22,7 +22,7 @@
         "id": "FIzICjaph_Wy"
       },
       "source": [
-        "<a align=\"center\" href=\"https://hub.ultralytics.com\" target=\"_blank\">\n",
+        "<a align=\"center\" href=\"https://bit.ly/ultralytics_hub\" target=\"_blank\">\n",
         "<img width=\"1024\", src=\"https://github.com/ultralytics/assets/raw/main/im/ultralytics-hub.png\"></a>\n",
         "\n",
         "<div align=\"center\">\n",


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update of Ultralytics HUB links to use a shortened URL.

### 📊 Key Changes
- All references to the Ultralytics HUB URL have been updated to a shortened bit.ly link (`https://bit.ly/ultralytics_hub`) in:
  - `README.md` (English version)
  - `README.zh-CN.md` (Chinese version)
  - `hub.ipynb` (Jupyter Notebook)

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To streamline access to Ultralytics HUB with a more manageable and possibly more shareable URL.
- 💥 **Impact**: Provides users with an easier way to reach Ultralytics HUB, potentially increasing traffic and user-friendliness. Existing bookmarks or links may need updating to the new URL.