### PR TITLE
Fix Ultralytics HUB link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ultralytics HUB datasets align with the format used by [YOLOv5](https://github.c
 
 ### Dataset Preparation:
 
-Ensure that the YAML file describing your dataset is placed in the root directory of your dataset, as illustrated below. Once in place, zip the directory for uploading to [Ultralytics HUB](https://bit.ly/ultralytics_hub/). The dataset YAML, its directory, and the zip file should all bear the identical name.
+Ensure that the YAML file describing your dataset is placed in the root directory of your dataset, as illustrated below. Once in place, zip the directory for uploading to [Ultralytics HUB](https://bit.ly/ultralytics_hub). The dataset YAML, its directory, and the zip file should all bear the identical name.
 
 For instance, with a dataset named 'coco8', as shown in [ultralytics/hub/example_datasets/coco8.zip](./example_datasets/coco8.zip), include a `coco8.yaml` within the `coco8/` directory. Zip this to form `coco8.zip` for upload with the command:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ Ultralytics HUB 数据集与 [YOLOv5](https://github.com/ultralytics/yolov5) 和
 
 ### 数据集准备：
 
-确保将描述您的数据集的 YAML 文件放在数据集的根目录下，如下所示。放置好后，将目录压缩以上传到 [Ultralytics HUB](https://bit.ly/ultralytics_hub/)。数据集 YAML、其目录和 zip 文件应该全部具有相同的名称。
+确保将描述您的数据集的 YAML 文件放在数据集的根目录下，如下所示。放置好后，将目录压缩以上传到 [Ultralytics HUB](https://bit.ly/ultralytics_hub)。数据集 YAML、其目录和 zip 文件应该全部具有相同的名称。
 
 例如，对于名为 'coco8' 的数据集，如 [ultralytics/hub/example_datasets/coco8.zip](./example_datasets/coco8.zip) 所示，包含一个 `coco8.yaml` 文件在 `coco8/` 目录中。将其压缩成 `coco8.zip` 以使用以下命令上传：
 


### PR DESCRIPTION
This PR updates the Ultralytics HUB broken link in `README.md` and `README.zh-CN.md`.

Refs: #617


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor update to Ultralytics HUB documentation regarding dataset upload instructions.

### 📊 Key Changes
- Updated the URL link for uploading datasets to Ultralytics HUB by removing the trailing slash.

### 🎯 Purpose & Impact
- **Clarity and Precision:** The URL modification is aimed at ensuring users are directed to the correct webpage without any issues. This helps in maintaining a seamless experience during dataset uploads.
- **Uniformity:** The change ensures consistency across documentation in English and Chinese, reducing confusion for international users.
- **User Experience:** Enhances the overall user experience by potentially fixing any link-related errors users might encounter during navigation.

This minor yet crucial adjustment helps maintain the integrity of user guidance and supports Ultralytics' commitment to providing clear and convenient access to their services. 🚀