### PR TITLE
Update Slack notification to mention @hub-team instead of @channel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ on:
 env:
   API_KEY: ${{ secrets.ULTRALYTICS_HUB_API_KEY }}
   MODEL_ID: ${{ secrets.ULTRALYTICS_HUB_MODEL_ID }}
+  HUB_TEAM_SLACK_ID: ${{ secrets.HUB_TEAM_SLACK_ID }}
 
 jobs:
   Tests:
@@ -99,6 +100,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |
-            {"text": "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"}
+            {"text": "<!subteam^${{ secrets.HUB_TEAM_SLACK_ID }}|@hub-team> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to change Slack notifications from `@channel` to `@hub-team`. By mentioning `@hub-team`, we ensure that only the relevant team members are notified when actions fail or are cancelled.

#### Additional Notes

- Please ensure that the `HUB_TEAM_SLACK_ID` secret is correctly set in the repository settings
- No other changes were made to the workflow beyond the Slack notification update


I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced GitHub Actions to notify specific Slack subteams.

### 📊 Key Changes
- Added `HUB_TEAM_SLACK_ID` secret to CI workflow.
- Updated Slack notification to target specific Slack subteams instead of the entire channel.

### 🎯 Purpose & Impact
- 🎯 **Targeted Notifications**: Ensures the right team members are notified, improving response times.
- 📈 **Efficiency**: Reduces noise for non-involved members, making the notification process more efficient.