### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: 🐛 Bug Report
 # title: " "
 description: Problems with HUB

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 blank_issues_enabled: true
 contact_links:
   - name: 📄 Docs

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: 🚀 Feature Request
 description: Suggest a HUB idea
 # title: " "

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: ❓ Question
 description: Ask a HUB question
 # title: " "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Dependabot for package version updates
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Ultralytics HUB Continuous Integration (CI) GitHub Actions tests
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: HUB CI
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Continuous Integration (CI) GitHub Actions tests broken link checker using https://github.com/lycheeverse/lychee
 # Ignores the following status codes to reduce false positives:
 #   - 403(OpenVINO, 'forbidden')

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, GPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
 on:

--- a/example_datasets/coco8-human/coco8-human.yaml
+++ b/example_datasets/coco8-human/coco8-human.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics coco8-human dataset: 8 images from COCO train2017 annotated with person weight (kg), height (cm), gender (0: female, 1: male), age (years) and ethnicity (0: asian, 1: white, 2: middle eastern, 3: indian, 4: latino, 5: black)
 # Documentation: https://docs.ultralytics.com/datasets/human
 # Example usage: yolo train data=coco8-human.yaml

--- a/example_datasets/coco8-pose/coco8-pose.yaml
+++ b/example_datasets/coco8-pose/coco8-pose.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # COCO8-pose dataset (first 8 images from COCO train2017) by Ultralytics for HUB https://hub.ultralytics.com
 # Example usage: yolo train data=coco8-pose.yaml
 # parent

--- a/example_datasets/coco8-seg/coco8-seg.yaml
+++ b/example_datasets/coco8-seg/coco8-seg.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # COCO8-seg dataset (first 8 images from COCO train2017) by Ultralytics for HUB https://hub.ultralytics.com
 # Example usage: yolo train data=coco8-seg.yaml
 # parent

--- a/example_datasets/coco8/coco8.yaml
+++ b/example_datasets/coco8/coco8.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # COCO8 dataset (first 8 images from COCO train2017) by Ultralytics for HUB https://hub.ultralytics.com
 # Example usage: yolo train data=coco8.yaml
 # parent

--- a/example_datasets/dota8/dota8.yaml
+++ b/example_datasets/dota8/dota8.yaml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # DOTA8 dataset 8 images from split DOTAv1 dataset by Ultralytics
 # Documentation: https://docs.ultralytics.com/datasets/obb/dota8/
 # Example usage: yolo train model=yolov8n-obb.pt data=dota8.yaml


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated license header across multiple files to consistently use the Ultralytics AGPL-3.0 license.

### 📊 Key Changes  
- Added/updated Ultralytics AGPL-3.0 license header in:  
  - Issue templates (bug report, feature request, question)  
  - GitHub workflows (CI, CLA, dependabot, formatting, link checks, stale issues)  
  - Example dataset configuration files (coco8, coco8-pose, coco8-seg, and others).

### 🎯 Purpose & Impact  
- **Purpose:** Ensure compliance and clarity by consistently referencing Ultralytics' AGPL-3.0 license in all relevant files.  
- **Impact:**  
  - Builds trust with users by clearly stating the licensing terms.  
  - Prevents ambiguity about usage rights for code and datasets.  
  - Improves repository documentation and legal compliance.  

💡 A simple yet essential update for transparency and professional polish! 🚀