### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: HUB CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/hub/security/code-scanning/2](https://github.com/ultralytics/hub/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not require write access to the repository, we can set `permissions: contents: read` at the root level of the workflow. This will apply the least privilege permissions to all jobs in the workflow unless overridden by job-specific permissions.

**Steps to implement the fix:**
1. Add a `permissions` block at the root level of the workflow file.
2. Set `contents: read` as the permission, which is sufficient for basic CI workflows.
3. Ensure no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved security settings for the Ultralytics HUB continuous integration (CI) workflow. 🔒

### 📊 Key Changes
- Added explicit permissions to the CI workflow, allowing only read access to repository contents.

### 🎯 Purpose & Impact
- Enhances security by restricting workflow permissions to the minimum required.
- Reduces potential risks from unauthorized access during automated CI runs.
- No impact on user-facing features or functionality; purely a behind-the-scenes improvement.