### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,10 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/hub/security/code-scanning/3](https://github.com/ultralytics/hub/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the `actions/stale` action to function correctly. Based on the functionality of the action (closing stale issues and pull requests), the required permissions are likely `contents: read`, `issues: write`, and `pull-requests: write`. These permissions should be added at the workflow level to apply to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
