### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,6 +10,9 @@
 
 name: Check Broken links
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/hub/security/code-scanning/1](https://github.com/ultralytics/hub/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow only uses the `GITHUB_TOKEN` for link checking, it likely only requires `contents: read` permissions. Adding this block at the root level ensures that all jobs in the workflow inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
