### PR TITLE
fix: 🐞 Add HUB login step before training and inference tests to prevent interactive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,16 @@ jobs:
         run: |
           yolo checks
           uv pip list
+      - name: Login to HUB
+        run: |
+          yolo login ${{ env.API_KEY }}
       - name: Test HUB training
         continue-on-error: false
         shell: python
         run: |
           import os
           from ultralytics import YOLO, hub
-          api_key, model_id = os.environ['API_KEY'], os.environ['MODEL_ID']
-          hub.login(api_key)
+          model_id = os.environ['MODEL_ID']
           hub.reset_model(model_id)
           model = YOLO('https://hub.ultralytics.com/models/' + model_id)
           model.train()
@@ -76,8 +78,7 @@ jobs:
           import time
           from ultralytics import YOLO, checks, hub
           checks()
-          api_key, model_id = os.environ['API_KEY'], os.environ['MODEL_ID']
-          hub.login(api_key)
+          model_id = os.environ['MODEL_ID']
           success = []
           for f in ('torchscript', 'onnx', 'openvino', 'coreml', 'saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs',
                     'paddle', 'ultralytics_tflite', 'ultralytics_coreml', 'ncnn'):


### PR DESCRIPTION


<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlines CI authentication with Ultralytics HUB by switching to a single CLI-based login step, simplifying tests and reducing inline credential handling 🔐🚀.

### 📊 Key Changes
- Adds a dedicated “Login to HUB” step in CI using `yolo login ${{ env.API_KEY }}`.
- Removes inline `hub.login(api_key)` calls from Python test scripts.
- Cleans up env handling by no longer reading `API_KEY` inside Python; only `MODEL_ID` remains.
- Keeps HUB training, reset, and export tests intact, now relying on the prior CLI login.

### 🎯 Purpose & Impact
- Improves security and hygiene by avoiding passing the API key through Python scripts.
- Simplifies CI configuration and reduces duplicated auth logic across steps.
- Enhances reliability of HUB interactions in CI by standardizing authentication.
- No changes for end users; contributors and maintainers see cleaner, more robust CI.

Example (recommended pattern):
```bash
# CI or local setup
yolo login $API_KEY
```
```python
# Python tests/scripts (no explicit hub.login needed)
from ultralytics import YOLO, hub

model_id = os.environ['MODEL_ID']
hub.reset_model(model_id)
model = YOLO(f'https://hub.ultralytics.com/models/{model_id}')
model.train()
```