### PR TITLE
Add `engine` to HUB export CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           model_id = os.environ['MODEL_ID']
           success = []
           for f in ('torchscript', 'onnx', 'openvino', 'coreml', 'saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs',
-                    'paddle', 'ultralytics_tflite', 'ultralytics_coreml', 'ncnn'):
+                    'paddle', 'ultralytics_tflite', 'ultralytics_coreml', 'ncnn', 'engine'):
               backoff_times = [60, 120, 240, 480]  # exponential backoff waits in seconds
               for wait_time in backoff_times:
                   try:


### PR DESCRIPTION
@yogendrasinghx @onuralpszr @yogendrasinghx

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds TensorRT "engine" export verification to Ultralytics HUB CI to ensure this format is produced and available reliably. 🚀

### 📊 Key Changes
- CI workflow now checks an additional export format: `engine` (TensorRT) alongside torchscript, onnx, openvino, coreml, tflite, ncnn, etc.
- Integrates `engine` into the existing exponential backoff polling logic to verify artifact availability.

### 🎯 Purpose & Impact
- Improves coverage of model export validations, catching TensorRT export issues early in CI ✅
- Increases reliability for users downloading TensorRT engine files from Ultralytics HUB 🧩
- No breaking changes; minor CI runtime increase due to one extra format check ⏱️