### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,21 +8,17 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       time: "04:00"
-    open-pull-requests-limit: 10
-    reviewers:
-      - glenn-jocher
+    open-pull-requests-limit: 3
     labels:
       - dependencies
 
   - package-ecosystem: github-actions
     directory: "/.github/workflows"
     schedule:
-      interval: weekly
+      interval: monthly
       time: "04:00"
-    open-pull-requests-limit: 5
-    reviewers:
-      - glenn-jocher
+    open-pull-requests-limit: 3
     labels:
       - dependencies


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Tune Dependabot settings to reduce PR noise by batching updates monthly and limiting concurrent PRs. 🧹📅

### 📊 Key Changes
- Change Dependabot schedule from weekly to monthly for:
  - pip dependencies
  - GitHub Actions workflows
- Reduce open Dependabot PR limit:
  - pip: from 10 ➝ 3
  - GitHub Actions: from 5 ➝ 3
- Remove automatic reviewer assignment of @glenn-jocher
- Keep the `dependencies` label on Dependabot PRs

### 🎯 Purpose & Impact
- Lower maintenance overhead and PR churn by batching updates less frequently ✅
- Fewer concurrent update PRs simplifies review and keeps CI pipelines cleaner 🧪
- Avoid overloading a single reviewer; teams can triage as needed 👥
- Slightly slower dependency updates; urgent security fixes may arrive later, so manual bumps might be needed if critical 🔒