### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: false
       - name: Install requirements


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the CI workflow to use `astral-sh/setup-uv@v8` instead of `@v7`, keeping the repository’s GitHub Actions setup current.

### 📊 Key Changes
- Updated the GitHub Actions step in `.github/workflows/ci.yml`
- Changed `astral-sh/setup-uv` from version `v7` to `v8`
- No application code or user-facing features were modified

### 🎯 Purpose & Impact
- 🚀 Keeps CI infrastructure aligned with the latest supported version of the `setup-uv` GitHub Action
- 🛠️ May improve reliability, compatibility, or maintenance of dependency setup in automated tests
- 📦 Reduces the risk of using outdated workflow tooling over time
- 👥 Minimal direct impact on end users, but helps maintain a healthier and more stable development pipeline