### PR TITLE
Bump astral-sh/setup-uv to v8 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: false
       - name: Install requirements


### PR DESCRIPTION
Bump astral-sh/setup-uv to v8 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by upgrading the `setup-uv` GitHub Action from `v7` to `v8` in the repository’s CI workflow.

### 📊 Key Changes
- Updated `.github/workflows/ci.yml`
- Changed the CI dependency setup step from `astral-sh/setup-uv@v7` to `astral-sh/setup-uv@v8`
- No application code, features, or user-facing behavior was modified

### 🎯 Purpose & Impact
- 🚀 Keeps the CI pipeline aligned with the latest supported version of the `setup-uv` action
- 🛠️ May improve workflow reliability, compatibility, and access to upstream fixes or improvements
- ✅ Helps reduce maintenance risk by avoiding older action versions
- 👥 No direct impact on end users, but contributors may benefit from a more up-to-date and stable development workflow