### PR TITLE
Test ultralytics/ultralytics#24185 in HUB CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           enable-cache: false
       - name: Install requirements
         run: |
-          uv pip install --system ultralytics hub-sdk --extra-index-url https://download.pytorch.org/whl/cpu
+          uv pip install --system "git+https://github.com/ultralytics/ultralytics.git@fix/hub-local-zip-datasets" hub-sdk --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Check environment
         run: |
           yolo checks


### PR DESCRIPTION
## Summary
- point HUB CI at `ultralytics/ultralytics` branch `fix/hub-local-zip-datasets`
- validate the fix from ultralytics/ultralytics#24185 in real HUB GitHub Actions

## Context
HUB training started failing on April 10, 2026 when zipped dataset handling hit:

```python
AttributeError: 'PosixPath' object has no attribute 'startswith'
```

The upstream fix is in:
- ultralytics/ultralytics#24185

This PR is only for CI validation in `ultralytics/hub`. Once that upstream PR is merged and released, this PR can be closed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates CI to install Ultralytics from a specific GitHub branch so `ultralytics/hub` can test against an unreleased fix for local ZIP dataset handling.

### 📊 Key Changes
- 🧪 Changed the CI dependency install step in `.github/workflows/ci.yml`.
- 📦 Replaced the standard `ultralytics` package install with a Git-based install from the `fix/hub-local-zip-datasets` branch.
- 🤝 Kept `hub-sdk` installation unchanged, so CI still tests HUB alongside the latest targeted Ultralytics code.
- ✅ Ensures CI runs against a version of Ultralytics that includes a pending fix before it is officially released.

### 🎯 Purpose & Impact
- 🚀 Lets the HUB repository validate compatibility with an upcoming fix for local ZIP datasets earlier.
- 🛠️ Reduces the risk of CI failures caused by relying on the currently published package version.
- 🔄 Helps coordinate development between `ultralytics/hub` and the main Ultralytics repository when a needed fix has not yet been released.
- 👀 For users, this should improve reliability around dataset-related workflows once the fix is merged and released.