### PR TITLE
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           assert all(success)
       - name: Notify on failure
         if: (cancelled() || failure()) && github.repository == 'ultralytics/hub' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small maintenance update by bumping the Slack GitHub Action in CI from `v3.0.1` to `v3.0.2` for failure notifications.

### 📊 Key Changes
- Updated the GitHub Actions workflow in `.github/workflows/ci.yml`
- Changed the Slack notification step to use `slackapi/slack-github-action@v3.0.2` instead of `@v3.0.1`
- The update applies specifically to the CI job that sends Slack alerts when scheduled or push-based runs fail or are canceled

### 🎯 Purpose & Impact
- ✅ Keeps CI dependencies current with the latest patch release
- 🛠️ May include minor fixes, reliability improvements, or security updates from the Slack action maintainers
- 📣 Helps ensure failure notifications to Slack remain stable, so the team can respond quickly to CI issues
- 🚀 Low-risk change with no expected impact on product features or end-user functionality