### PR TITLE
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           assert all(success)
       - name: Notify on failure
         if: (cancelled() || failure()) && github.repository == 'ultralytics/hub' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small but important maintenance update by bumping the Slack GitHub Action in CI from `v3.0.2` to `v3.0.3`.

### 📊 Key Changes
- ⬆️ Updated the GitHub Actions step used for CI failure notifications:
  - from `slackapi/slack-github-action@v3.0.2`
  - to `slackapi/slack-github-action@v3.0.3`
- 📣 This affects the workflow step that sends Slack alerts when scheduled or push-based CI runs fail in `ultralytics/hub`.
- 🛠️ No application code or product features were changed—this is a CI/workflow dependency update only.

### 🎯 Purpose & Impact
- ✅ Keeps the CI notification system up to date with the latest patch release of the Slack action.
- 🔒 May improve reliability, stability, or compatibility for failure alerts without changing existing workflow behavior.
- 👀 Helps the team catch CI issues quickly by ensuring Slack notifications continue to work as expected.
- 🚫 No direct impact on end users or platform functionality, but it supports smoother developer operations behind the scenes.