### PR TITLE
Update READMEs for Platform migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,97 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com" target="_blank">
-      <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif" alt="Ultralytics Platform dataset interface"></a>
+    <a href="https://platform.ultralytics.com/ultralytics/yolo26?utm_source=github&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=platform_readme" target="_blank">
+      <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
   </p>
 
-[中文](https://docs.ultralytics.com/zh/platform) | [한국어](https://docs.ultralytics.com/ko/platform) | [日本語](https://docs.ultralytics.com/ja/platform) | [Русский](https://docs.ultralytics.com/ru/platform) | [Deutsch](https://docs.ultralytics.com/de/platform) | [Français](https://docs.ultralytics.com/fr/platform) | [Español](https://docs.ultralytics.com/es/platform) | [Português](https://docs.ultralytics.com/pt/platform) | [Türkçe](https://docs.ultralytics.com/tr/platform) | [Tiếng Việt](https://docs.ultralytics.com/vi/platform) | [العربية](https://docs.ultralytics.com/ar/platform)
+[中文](README.zh-CN.md) | [한국어](https://docs.ultralytics.com/ko/platform) | [日本語](https://docs.ultralytics.com/ja/platform) | [Русский](https://docs.ultralytics.com/ru/platform) | [Deutsch](https://docs.ultralytics.com/de/platform) | [Français](https://docs.ultralytics.com/fr/platform) | [Español](https://docs.ultralytics.com/es/platform) | [Português](https://docs.ultralytics.com/pt/platform) | [Türkçe](https://docs.ultralytics.com/tr/platform) | [Tiếng Việt](https://docs.ultralytics.com/vi/platform) | [العربية](https://docs.ultralytics.com/ar/platform)
 
-[![Ultralytics Actions](https://github.com/ultralytics/hub/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/hub/actions/workflows/ci.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
-<a href="https://colab.research.google.com/github/ultralytics/hub/blob/main/hub.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
+</div>
 
-👋 Welcome from the [Ultralytics](https://www.ultralytics.com/) Team! Ultralytics HUB is being deprecated and will be wound down at the end of July 2026. New projects should use the new [Ultralytics Platform](https://platform.ultralytics.com), the end-to-end computer vision platform for preparing data, annotating images, training YOLO models, exporting to production formats, and deploying monitored endpoints across global regions. 🚀
+Welcome from the [Ultralytics](https://www.ultralytics.com/) team. This repository now provides legacy support for existing Ultralytics HUB users while they migrate datasets, models, and workflows to [Ultralytics Platform](https://platform.ultralytics.com), the end-to-end computer vision platform for data preparation, annotation, YOLO model training, export, deployment, and monitoring.
 
-Create a [Platform account](https://platform.ultralytics.com) to start new work. Existing HUB users can migrate all HUB datasets and models directly by pasting their HUB API key into **Settings > Integrations > Ultralytics HUB** after account creation. Explore the [Ultralytics Platform documentation](https://docs.ultralytics.com/platform/quickstart), open [GitHub Issues](https://github.com/ultralytics/hub/issues/new/choose) for legacy HUB repository support, and join our [Discord community](https://discord.com/invite/ultralytics) for discussions and collaboration!
+> [!WARNING]
+> Ultralytics HUB is being deprecated and will be wound down at the end of July 2026. Start all new computer vision work on Ultralytics Platform. Existing HUB users should migrate active datasets and models to Platform before the shutdown date.
+
+Create a [Platform account](https://platform.ultralytics.com) to start new work. Existing HUB users can migrate datasets and models by creating a Platform account, then pasting their HUB API key into **Settings > Integrations > Ultralytics HUB**. For legacy repository support and migration questions, open an issue from this repository's **Issues** tab.
+
+<p align="center">
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif" alt="Ultralytics Platform dataset interface">
+</p>
 
 <br>
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="2%" alt="Ultralytics GitHub"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="2%" alt="Ultralytics LinkedIn"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="2%" alt="Ultralytics Twitter"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="2%" alt="Ultralytics YouTube"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="2%" alt="Ultralytics TikTok"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="2%" alt="Ultralytics BiliBili"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="2%" alt="Ultralytics Discord"></a>
-</div>
 </div>
 
 ## 🗂️ Prepare and Upload Datasets
 
-Ultralytics Platform datasets follow the same structure and labeling conventions as [YOLO11](https://docs.ultralytics.com/models/yolo11), [YOLOv8](https://docs.ultralytics.com/models/yolov8), and [YOLOv5](https://docs.ultralytics.com/models/yolov5), ensuring seamless compatibility for [object detection](https://docs.ultralytics.com/tasks/detect), [instance segmentation](https://docs.ultralytics.com/tasks/segment), [pose estimation](https://docs.ultralytics.com/tasks/pose), [oriented object detection](https://docs.ultralytics.com/tasks/obb), and [image classification](https://docs.ultralytics.com/tasks/classify) projects.
+Ultralytics Platform datasets support the same YOLO task families used across [YOLO26](https://docs.ultralytics.com/models/yolo26), [YOLO11](https://docs.ultralytics.com/models/yolo11), [YOLOv8](https://docs.ultralytics.com/models/yolov8), and [YOLOv5](https://docs.ultralytics.com/models/yolov5): [object detection](https://docs.ultralytics.com/tasks/detect), [instance segmentation](https://docs.ultralytics.com/tasks/segment), [pose estimation](https://docs.ultralytics.com/tasks/pose), [oriented object detection](https://docs.ultralytics.com/tasks/obb), and [image classification](https://docs.ultralytics.com/tasks/classify).
 
+- Upload images up to 50 MB, videos up to 1 GB, and ZIP, TAR, `.tar.gz`, `.tgz`, or NDJSON dataset files.
+- Use Platform to automatically validate uploads, resize large images, generate thumbnails, parse labels, and compute statistics.
+- Review and label data in grid, compact, and table views with annotation overlays, split filters, label filters, class filters, and filename search.
+- Annotate detect, segment, pose, OBB, and classify datasets with manual tools, skeleton templates, Smart Annotation with SAM, and YOLO auto-labeling.
 - Review dataset best practices in the [Ultralytics datasets documentation](https://docs.ultralytics.com/datasets).
 - Learn about dataset annotation and preparation in the [data collection and annotation guide](https://docs.ultralytics.com/guides/data-collection-and-annotation).
 - Explore open-source datasets such as [COCO](https://docs.ultralytics.com/datasets/detect/coco), [LVIS](https://docs.ultralytics.com/datasets/detect/lvis), and [ImageNet](https://docs.ultralytics.com/datasets/classify/imagenet).
-- Upload ZIP, TAR, image, video, or NDJSON data to [Ultralytics Platform](https://platform.ultralytics.com) for automatic processing, analysis, manual annotation, and Smart Annotation.
 
 ### Dataset Preparation
 
-Place your dataset YAML file in the root directory of your dataset. The YAML file, its directory, and the zipped archive should all share the same name for easy upload to [Ultralytics Platform](https://platform.ultralytics.com). For example, for a dataset called `coco8`, your structure should look like:
+Navigate to **Annotate** in Platform and click **New Dataset**, or drag files onto the Datasets card on the Home dashboard. For best results, upload a ZIP or TAR archive with a standard YOLO structure:
 
-- `coco8/`
-  - `coco8.yaml`
-  - `images/`
-  - `labels/`
-- `coco8.zip` (the zipped directory for upload)
+```text
+my-dataset.zip
+├── data.yaml
+├── train/
+│   ├── images/
+│   │   ├── img001.jpg
+│   │   └── img002.jpg
+│   └── labels/
+│       ├── img001.txt
+│       └── img002.txt
+└── val/
+    ├── images/
+    └── labels/
+```
 
 You can zip your dataset using:
 
 ```bash
 # Zip the dataset directory for upload
-zip -r coco8.zip coco8
+zip -r my-dataset.zip my-dataset
 ```
 
-See [example_datasets/coco8.zip](./example_datasets/coco8.zip) for a working example. For more on dataset formats, visit the [Ultralytics datasets documentation](https://docs.ultralytics.com/datasets).
+See [example_datasets/coco8.zip](./example_datasets/coco8.zip) and the local `example_datasets/` directory for small YOLO-format archives. For more on dataset formats, visit the [Ultralytics datasets documentation](https://docs.ultralytics.com/datasets). Platform also accepts COCO JSON annotations, Ultralytics NDJSON exports, classification folder layouts, videos, and raw unannotated images for labeling in the annotation editor.
 
 <p align="center">
-<img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/docs/hub/datasets/hub_upload_dataset_1.jpg" title="COCO8 Example Dataset Structure" />
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-quickstart-upload-dialog.avif" alt="Ultralytics Platform upload dialog">
 </p>
 
 ### YAML Specifications
 
-The dataset YAML should follow the [YOLO dataset format](https://docs.ultralytics.com/guides/model-training-tips). For detailed instructions, see the [model training tips guide](https://docs.ultralytics.com/guides/model-training-tips).
+The dataset YAML should define dataset paths and class names using standard [YOLO dataset format](https://docs.ultralytics.com/guides/model-training-tips) conventions. For detailed instructions, see the [model training tips guide](https://docs.ultralytics.com/guides/model-training-tips).
 
 ```yaml
 # Example YAML configuration for a custom dataset
-path: ../datasets/coco8 # dataset root directory (relative or absolute)
-train: images/train # training images (relative to 'path')
-val: images/val # validation images (relative to 'path')
+path: .
+train: train/images
+val: val/images
 test: # test images (optional)
 
 # Class labels
@@ -86,60 +103,82 @@ names:
   # Add more classes as needed
 ```
 
-Upload your zipped dataset to [Ultralytics Platform](https://platform.ultralytics.com) by logging in, navigating to the [Datasets page](https://docs.ultralytics.com/platform/data/datasets), and selecting 'Upload Dataset'. You can preview, analyze, annotate, and train from the dataset in the same workflow.
-
-<p align="center">
-  <img width="100%" alt="Ultralytics Platform Dataset Upload Interface" src="https://user-images.githubusercontent.com/26833433/216763338-9a8812c8-a4e5-4362-8102-40dad7818396.png">
-</p>
+After upload, Platform checks image and label validity, generates previews, computes class and dimension statistics, and makes ready datasets available for annotation, cloud training, and local training through `ul://` dataset URIs.
 
 ## 🚀 Train a Model
 
-Use [Ultralytics Platform](https://platform.ultralytics.com) to train YOLO models on cloud GPUs, stream remote-training metrics, compare experiments inside projects, and manage trained `.pt` models in one place. Legacy HUB notebook workflows remain available in this repository for existing users during the wind-down period, but new training should start on Platform.
+Use [Ultralytics Platform](https://platform.ultralytics.com) to train YOLO models on cloud GPUs, compare experiments inside projects, manage trained `.pt` models, and stream local training metrics. Legacy HUB support remains available in this repository during the migration window, but new training should start on Platform.
 
+- Click **Train Model** from a project, select a dataset, choose an official YOLO model or one of your trained models, set epochs and image size, and select a GPU.
+- Monitor real-time charts, console logs, and system metrics while training runs.
+- Use the best checkpoint after training for download, export, browser prediction, and deployment.
+- Train locally with `ultralytics>=8.4.35` and stream metrics to Platform using your API key.
 - Discover [model training tips](https://docs.ultralytics.com/guides/model-training-tips) for best practices.
 - Learn about [hyperparameter tuning](https://docs.ultralytics.com/guides/hyperparameter-tuning) to optimize your results.
 - Explore [experiment tracking integrations](https://docs.ultralytics.com/integrations/mlflow) for reproducible research.
 
-<a href="https://colab.research.google.com/github/ultralytics/hub/blob/main/hub.ipynb" target="_blank">
-    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab" />
-</a>
+<p align="center">
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-quickstart-training-dialog-cloud-tab.avif" alt="Ultralytics Platform cloud training dialog">
+</p>
+
+```bash
+pip install -U ultralytics
+export ULTRALYTICS_API_KEY="YOUR_API_KEY"
+
+yolo train model=yolo26n.pt data=coco.yaml epochs=100 project=username/my-project name=experiment-1
+```
+
+Platform datasets can be used directly from training jobs with `ul://` dataset URIs:
+
+```bash
+yolo train model=yolo26n.pt data=ul://username/datasets/my-dataset epochs=100 project=username/my-project name=experiment-1
+```
 
 ## 🌐 Deploy to the Real World
 
-After training, deploy your models to production using [Ultralytics Platform](https://platform.ultralytics.com) or the [Export mode](https://docs.ultralytics.com/modes/export). Platform supports browser prediction, monitored deployments, global dedicated endpoints, and 17+ export formats, including [TensorFlow](https://www.tensorflow.org/), [ONNX](https://onnx.ai/), [OpenVINO](https://docs.openvino.ai/latest/index.html), [TensorRT](https://developer.nvidia.com/tensorrt), [CoreML](https://developer.apple.com/documentation/coreml), [PaddlePaddle](https://www.paddlepaddle.org.cn/en), and more.
+After training, use Platform to test models in the browser, export to production formats, and deploy dedicated endpoints. Platform supports browser prediction, monitored deployments, 43 global deployment regions, scale-to-zero behavior, and 17 export formats including [ONNX](https://onnx.ai/), [TensorRT](https://developer.nvidia.com/tensorrt), [CoreML](https://developer.apple.com/documentation/coreml), [TFLite](https://www.tensorflow.org/lite), [OpenVINO](https://docs.openvino.ai/latest/index.html), and TorchScript.
 
+- Open the model **Predict** tab to upload images, tune confidence, IoU, and image size, and review predictions on canvas.
+- Use the **Deploy** tab to select a region from the latency map and create a dedicated HTTPS endpoint.
+- Monitor endpoint health, request logs, P95 latency, error rate, and usage metrics from Platform.
+- Use ready-to-run Python, JavaScript, and cURL examples generated for your endpoint.
 - Learn about [model deployment options](https://docs.ultralytics.com/guides/model-deployment-options) for edge and cloud.
 - Explore [optimizing OpenVINO latency vs throughput](https://docs.ultralytics.com/guides/optimizing-openvino-latency-vs-throughput-modes) for real-time inference.
-- Run your models on [iOS](https://apps.apple.com/app/ultralytics/id1583935240) or [Android](https://play.google.com/store/apps/details?id=com.ultralytics.ultralytics_app) devices with the [Ultralytics App](https://www.ultralytics.com/app-install).
+- Run models on [iOS](https://apps.apple.com/app/ultralytics/id1583935240) or [Android](https://play.google.com/store/apps/details?id=com.ultralytics.ultralytics_app) devices with the [Ultralytics App](https://www.ultralytics.com/app-install).
+
+<p align="center">
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-deploy-tab-region-map-with-latency.avif" alt="Ultralytics Platform deployment region map">
+</p>
 
 ## ❓ Have Issues or Questions?
 
-For new work, start with [Ultralytics Platform](https://platform.ultralytics.com) and the [Platform quickstart](https://docs.ultralytics.com/platform/quickstart). If you need to move existing HUB work before the end of July 2026 wind-down, create a Platform account and paste your HUB API key into **Settings > Integrations > Ultralytics HUB** to migrate all HUB datasets and models.
+For new work, start with [Ultralytics Platform](https://platform.ultralytics.com) and the [Platform quickstart](https://docs.ultralytics.com/platform/quickstart). If you need to move existing HUB work before the end of July 2026 wind-down, create a Platform account and paste your HUB API key into **Settings > Integrations > Ultralytics HUB** to migrate datasets and models.
 
-- Use [GitHub Issues](https://github.com/ultralytics/hub/issues) for legacy HUB repository support and migration questions.
+- Use this repository's **Issues** tab for legacy HUB repository support and migration questions.
 - Visit the [Ultralytics help center](https://docs.ultralytics.com/help/FAQ) for quick answers.
 - Explore the [Ultralytics help center](https://docs.ultralytics.com/help) for troubleshooting and best practices.
+- Explore the [Ultralytics Platform documentation](https://docs.ultralytics.com/platform) for current workflows.
 - Join the [Ultralytics Discord community](https://discord.com/invite/ultralytics) for real-time discussions.
 
 ## 🤝 Contribute
 
-We welcome and value your contributions! ❤️ See our [Contributing Guide](https://docs.ultralytics.com/help/contributing) for details on how to get involved. Thank you to all our amazing contributors!
+We welcome contributions that improve legacy migration support, clarify Platform onboarding, or fix repository examples. See our [Contributing Guide](https://docs.ultralytics.com/help/contributing) for details on how to get involved. Thank you to all our contributors!
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
 <br>
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
 </div>

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can zip your dataset using:
 
 ```bash
 # Zip the dataset directory for upload
-zip -r my-dataset.zip my-dataset
+cd my-dataset && zip -r ../my-dataset.zip .
 ```
 
 See [example_datasets/coco8.zip](./example_datasets/coco8.zip) and the local `example_datasets/` directory for small YOLO-format archives. For more on dataset formats, visit the [Ultralytics datasets documentation](https://docs.ultralytics.com/datasets). Platform also accepts COCO JSON annotations, Ultralytics NDJSON exports, classification folder layouts, videos, and raw unannotated images for labeling in the annotation editor.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+
 </div>
 
 Welcome from the [Ultralytics](https://www.ultralytics.com/) team. This repository now provides legacy support for existing Ultralytics HUB users while they migrate datasets, models, and workflows to [Ultralytics Platform](https://platform.ultralytics.com), the end-to-end computer vision platform for data preparation, annotation, YOLO model training, export, deployment, and monitoring.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,69 +1,97 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com" target="_blank">
-      <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif" alt="Ultralytics Platform dataset interface"></a>
+    <a href="https://platform.ultralytics.com/ultralytics/yolo26?utm_source=github&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=platform_readme" target="_blank">
+      <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
   </p>
 
-[中文](https://docs.ultralytics.com/zh/platform) | [한국어](https://docs.ultralytics.com/ko/platform) | [日本語](https://docs.ultralytics.com/ja/platform) | [Русский](https://docs.ultralytics.com/ru/platform) | [Deutsch](https://docs.ultralytics.com/de/platform) | [Français](https://docs.ultralytics.com/fr/platform) | [Español](https://docs.ultralytics.com/es/platform) | [Português](https://docs.ultralytics.com/pt/platform) | [Türkçe](https://docs.ultralytics.com/tr/platform) | [Tiếng Việt](https://docs.ultralytics.com/vi/platform) | [العربية](https://docs.ultralytics.com/ar/platform)
+[English](README.md) | [한국어](https://docs.ultralytics.com/ko/platform) | [日本語](https://docs.ultralytics.com/ja/platform) | [Русский](https://docs.ultralytics.com/ru/platform) | [Deutsch](https://docs.ultralytics.com/de/platform) | [Français](https://docs.ultralytics.com/fr/platform) | [Español](https://docs.ultralytics.com/es/platform) | [Português](https://docs.ultralytics.com/pt/platform) | [Türkçe](https://docs.ultralytics.com/tr/platform) | [Tiếng Việt](https://docs.ultralytics.com/vi/platform) | [العربية](https://docs.ultralytics.com/ar/platform)
 
-[![Ultralytics Actions](https://github.com/ultralytics/hub/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/hub/actions/workflows/ci.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
-<a href="https://colab.research.google.com/github/ultralytics/hub/blob/main/hub.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
+</div>
 
-👋 来自 [Ultralytics](https://www.ultralytics.com/) 团队的问候！Ultralytics HUB 正在逐步停用，并将于 2026 年 7 月底完成下线。新项目请使用全新的 [Ultralytics Platform](https://platform.ultralytics.com)，这是面向计算机视觉的端到端平台，覆盖数据准备、图像标注、YOLO 模型训练、生产格式导出和全球多区域端点部署 🚀！
+来自 [Ultralytics](https://www.ultralytics.com/) 团队的问候。本仓库现在用于为现有 Ultralytics HUB 用户提供旧版支持，帮助他们将数据集、模型和工作流迁移到 [Ultralytics Platform](https://platform.ultralytics.com)。Platform 是端到端计算机视觉平台，覆盖数据准备、标注、YOLO 模型训练、导出、部署和监控。
 
-请创建 [Platform 账号](https://platform.ultralytics.com) 开始新的工作流。现有 HUB 用户在创建账号后，可进入 **Settings > Integrations > Ultralytics HUB** 粘贴 HUB API key，直接迁移所有 HUB 数据集和模型。欢迎查阅 [Ultralytics Platform 文档](https://docs.ultralytics.com/platform/quickstart) 了解详细指南，在 [GitHub Issues](https://github.com/ultralytics/hub/issues/new/choose) 提交旧版 HUB 仓库支持问题，并加入我们的 [Discord 社区](https://discord.com/invite/ultralytics) 参与讨论！
+> [!WARNING]
+> Ultralytics HUB 正在逐步停用，并将于 2026 年 7 月底完成下线。所有新的计算机视觉工作都应从 Ultralytics Platform 开始。现有 HUB 用户应在下线日期前将仍在使用的数据集和模型迁移到 Platform。
+
+请创建 [Platform 账号](https://platform.ultralytics.com) 开始新的工作流。现有 HUB 用户可在创建 Platform 账号后，进入 **Settings > Integrations > Ultralytics HUB** 粘贴 HUB API key，迁移数据集和模型。如需旧版仓库支持或迁移帮助，请在本仓库的 **Issues** 页面提交问题。
+
+<p align="center">
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif" alt="Ultralytics Platform dataset interface">
+</p>
 
 <br>
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="2%" alt="Ultralytics GitHub"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="2%" alt="Ultralytics LinkedIn"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="2%" alt="Ultralytics Twitter"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="2%" alt="Ultralytics YouTube"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="2%" alt="Ultralytics TikTok"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="2%" alt="Ultralytics BiliBili"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">
   <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="2%" alt="Ultralytics Discord"></a>
-</div>
 </div>
 
 ## 🗂️ 准备和上传数据集
 
-Ultralytics Platform 数据集格式与 [YOLO11](https://docs.ultralytics.com/models/yolo11)、[YOLOv8](https://docs.ultralytics.com/models/yolov8) 和 [YOLOv5](https://docs.ultralytics.com/models/yolov5) 完全兼容。它们采用统一的结构和标签规范，支持 [目标检测](https://docs.ultralytics.com/tasks/detect)、[实例分割](https://docs.ultralytics.com/tasks/segment)、[姿态估计](https://docs.ultralytics.com/tasks/pose)、[定向目标检测](https://docs.ultralytics.com/tasks/obb) 和 [图像分类](https://docs.ultralytics.com/tasks/classify) 等任务。
+Ultralytics Platform 数据集支持 [YOLO26](https://docs.ultralytics.com/models/yolo26)、[YOLO11](https://docs.ultralytics.com/models/yolo11)、[YOLOv8](https://docs.ultralytics.com/models/yolov8) 和 [YOLOv5](https://docs.ultralytics.com/models/yolov5) 使用的 YOLO 任务体系：[目标检测](https://docs.ultralytics.com/tasks/detect)、[实例分割](https://docs.ultralytics.com/tasks/segment)、[姿态估计](https://docs.ultralytics.com/tasks/pose)、[定向目标检测](https://docs.ultralytics.com/tasks/obb) 和 [图像分类](https://docs.ultralytics.com/tasks/classify)。
+
+- 可上传最大 50 MB 图像、最大 1 GB 视频，以及 ZIP、TAR、`.tar.gz`、`.tgz` 或 NDJSON 数据集文件。
+- Platform 会自动校验上传内容、缩放大图、生成缩略图、解析标签并计算统计信息。
+- 可在 grid、compact 和 table 视图中查看标注叠加层，并使用 split、标签、类别和文件名过滤。
+- 支持使用手动工具、骨架模板、SAM Smart Annotation 和 YOLO 自动标注处理 detect、segment、pose、OBB 和 classify 数据集。
+- 请查看 [Ultralytics 数据集文档](https://docs.ultralytics.com/datasets) 了解数据集最佳实践。
+- 通过 [数据收集与标注指南](https://docs.ultralytics.com/guides/data-collection-and-annotation) 学习数据准备和标注流程。
+- 探索 [COCO](https://docs.ultralytics.com/datasets/detect/coco)、[LVIS](https://docs.ultralytics.com/datasets/detect/lvis) 和 [ImageNet](https://docs.ultralytics.com/datasets/classify/imagenet) 等开源数据集。
 
 ### 数据集准备
 
-请确保您的数据集根目录下包含描述数据集的 YAML 文件。准备好后，将整个目录压缩为 ZIP 文件，便于上传至 [Ultralytics Platform](https://platform.ultralytics.com)。YAML 文件、其所在目录及压缩包需保持同名。
+进入 Platform 的 **Annotate** 并点击 **New Dataset**，或将文件拖放到 Home dashboard 的 Datasets 卡片中。建议上传采用标准 YOLO 结构的 ZIP 或 TAR 压缩包：
 
-例如，若您的数据集名为 'coco8'，请参考 [ultralytics/hub/example_datasets/coco8.zip](./example_datasets/coco8.zip) 的结构，在 `coco8/` 目录下放置 `coco8.yaml` 文件。然后使用如下命令将其压缩：
+```text
+my-dataset.zip
+├── data.yaml
+├── train/
+│   ├── images/
+│   │   ├── img001.jpg
+│   │   └── img002.jpg
+│   └── labels/
+│       ├── img001.txt
+│       └── img002.txt
+└── val/
+    ├── images/
+    └── labels/
+```
+
+可以使用以下命令压缩数据集：
 
 ```bash
 # 压缩数据集目录以便上传
-zip -r coco8.zip coco8
+zip -r my-dataset.zip my-dataset
 ```
 
-建议浏览 [example_datasets/coco8.zip](./example_datasets/coco8.zip) 获取自定义数据集构建的实际案例。更多数据集格式说明，请参阅 [Ultralytics 数据集文档](https://docs.ultralytics.com/datasets)。
+请参考 [example_datasets/coco8.zip](./example_datasets/coco8.zip) 和本地 `example_datasets/` 目录中的小型 YOLO 格式压缩包示例。更多数据集格式说明，请参阅 [Ultralytics 数据集文档](https://docs.ultralytics.com/datasets)。Platform 也支持 COCO JSON 标注、Ultralytics NDJSON 导出、分类文件夹布局、视频，以及用于在线标注的原始未标注图像。
 
 <p align="center">
-<img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/docs/hub/datasets/hub_upload_dataset_1.jpg" title="COCO8 Example Dataset Structure" />
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-quickstart-upload-dialog.avif" alt="Ultralytics Platform upload dialog">
 </p>
 
 ### YAML 规范
 
-数据集 YAML 文件遵循 YOLO 格式规范。详细说明请参考 [训练自定义数据指南](https://docs.ultralytics.com/guides/model-training-tips)。
+数据集 YAML 文件应使用标准 [YOLO 数据集格式](https://docs.ultralytics.com/guides/model-training-tips) 约定定义数据路径和类别名称。详细说明请参考 [模型训练技巧指南](https://docs.ultralytics.com/guides/model-training-tips)。
 
 ```yaml
 # 自定义数据集 YAML 配置示例
-path: ../datasets/coco8 # 数据集根目录（相对或绝对路径）
-train: images/train # 训练图像（相对 'path'）8 张图像
-val: images/val # 验证图像（相对 'path'）8 张图像
+path: .
+train: train/images
+val: val/images
 test: # 测试图像（可选）
 
 # 类别标签
@@ -75,47 +103,82 @@ names:
   # 可根据需要添加更多类别
 ```
 
-登录 [Ultralytics Platform](https://platform.ultralytics.com)，前往 ['Datasets' 页面](https://docs.ultralytics.com/platform/data/datasets)，点击 'Upload Dataset' 上传您的 ZIP 数据集。上传后，您可在同一工作流中预览、分析、标注并训练数据集。
-
-<p align="center">
-  <img width="100%" alt="Ultralytics Platform Dataset Upload Interface" src="https://user-images.githubusercontent.com/26833433/216763338-9a8812c8-a4e5-4362-8102-40dad7818396.png">
-</p>
+上传后，Platform 会检查图像和标签有效性、生成预览、计算类别和尺寸统计信息，并让 ready 状态的数据集可用于标注、云端训练，以及通过 `ul://` 数据集 URI 进行本地训练。
 
 ## 🚀 训练模型
 
-使用 [Ultralytics Platform](https://platform.ultralytics.com) 可在云端 GPU 上训练 YOLO 模型、流式同步远程训练指标、在项目中比较实验结果，并集中管理训练好的 `.pt` 模型。旧版 HUB notebook 工作流会在 HUB 下线过渡期内继续保留给现有用户，但新的训练工作应从 Platform 开始。
+使用 [Ultralytics Platform](https://platform.ultralytics.com) 可在云端 GPU 上训练 YOLO 模型、在项目中比较实验、管理训练好的 `.pt` 模型，并流式同步本地训练指标。本仓库会在迁移窗口内继续提供旧版 HUB 支持，但新的训练工作应从 Platform 开始。
 
-<a href="https://colab.research.google.com/github/ultralytics/hub/blob/main/hub.ipynb" target="_blank">
-    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab" />
-</a>
+- 在项目中点击 **Train Model**，选择数据集、官方 YOLO 模型或您自己的已训练模型，设置 epochs 和 image size，然后选择 GPU。
+- 训练运行时可查看实时图表、控制台日志和系统指标。
+- 训练完成后，最佳 checkpoint 可用于下载、导出、浏览器预测和部署。
+- 使用 `ultralytics>=8.4.35` 和 API key，可在本地训练并将指标流式同步到 Platform。
+- 阅读 [模型训练技巧](https://docs.ultralytics.com/guides/model-training-tips) 了解最佳实践。
+- 学习 [超参数调优](https://docs.ultralytics.com/guides/hyperparameter-tuning) 以优化结果。
+- 探索 [实验跟踪集成](https://docs.ultralytics.com/integrations/mlflow)，支持可复现研究。
+
+<p align="center">
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-quickstart-training-dialog-cloud-tab.avif" alt="Ultralytics Platform cloud training dialog">
+</p>
+
+```bash
+pip install -U ultralytics
+export ULTRALYTICS_API_KEY="YOUR_API_KEY"
+
+yolo train model=yolo26n.pt data=coco.yaml epochs=100 project=username/my-project name=experiment-1
+```
+
+Platform 数据集也可通过 `ul://` URI 直接用于训练任务：
+
+```bash
+yolo train model=yolo26n.pt data=ul://username/datasets/my-dataset epochs=100 project=username/my-project name=experiment-1
+```
 
 ## 🌐 部署到现实世界
 
-利用 [Ultralytics Platform](https://platform.ultralytics.com) 或 [导出模式](https://docs.ultralytics.com/modes/export)，可将训练好的模型部署到生产环境。Platform 支持浏览器预测、监控部署、全球专用端点，以及 17+ 种导出格式，包括 [TensorFlow](https://www.tensorflow.org/)、[ONNX](https://onnx.ai/)、[OpenVINO](https://docs.openvino.ai/latest/index.html)、[TensorRT](https://developer.nvidia.com/tensorrt)、[CoreML](https://developer.apple.com/documentation/coreml)、[PaddlePaddle](https://www.paddlepaddle.org.cn/en) 等。下载 [Ultralytics App](https://www.ultralytics.com/app-install)，即可在 [iOS](https://apps.apple.com/app/ultralytics/id1583935240) 或 [Android](https://play.google.com/store/apps/details?id=com.ultralytics.ultralytics_app) 移动设备上直接运行您的模型！探索更多适用于边缘设备和云平台的 [模型部署选项](https://docs.ultralytics.com/guides/model-deployment-options)。
+训练完成后，可使用 Platform 在浏览器中测试模型、导出生产格式并部署专用端点。Platform 支持浏览器预测、监控部署、43 个全球部署区域、scale-to-zero，以及 17 种导出格式，包括 [ONNX](https://onnx.ai/)、[TensorRT](https://developer.nvidia.com/tensorrt)、[CoreML](https://developer.apple.com/documentation/coreml)、[TFLite](https://www.tensorflow.org/lite)、[OpenVINO](https://docs.openvino.ai/latest/index.html) 和 TorchScript。
+
+- 打开模型 **Predict** 标签页即可上传图像、调整 confidence、IoU 和 image size，并在画布上查看预测结果。
+- 在 **Deploy** 标签页中，从延迟地图选择区域并创建专用 HTTPS 端点。
+- 可在 Platform 中监控端点健康状态、请求日志、P95 延迟、错误率和用量指标。
+- Platform 会为您的端点生成可直接使用的 Python、JavaScript 和 cURL 示例。
+- 了解适用于边缘设备和云端的 [模型部署选项](https://docs.ultralytics.com/guides/model-deployment-options)。
+- 探索 [OpenVINO 延迟与吞吐优化](https://docs.ultralytics.com/guides/optimizing-openvino-latency-vs-throughput-modes)，用于实时推理。
+- 下载 [Ultralytics App](https://www.ultralytics.com/app-install)，即可在 [iOS](https://apps.apple.com/app/ultralytics/id1583935240) 或 [Android](https://play.google.com/store/apps/details?id=com.ultralytics.ultralytics_app) 移动设备上运行模型。
+
+<p align="center">
+  <img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-deploy-tab-region-map-with-latency.avif" alt="Ultralytics Platform deployment region map">
+</p>
 
 ## ❓ 有问题或疑问？
 
-新项目请从 [Ultralytics Platform](https://platform.ultralytics.com) 和 [Platform 快速开始](https://docs.ultralytics.com/platform/quickstart) 开始。如果您需要在 2026 年 7 月底 HUB 下线前迁移现有工作，请创建 Platform 账号，并在 **Settings > Integrations > Ultralytics HUB** 粘贴 HUB API key，即可迁移所有 HUB 数据集和模型。[GitHub Issues](https://github.com/ultralytics/hub/issues) 可用于旧版 HUB 仓库支持和迁移问题反馈。
+新的工作请从 [Ultralytics Platform](https://platform.ultralytics.com) 和 [Platform 快速开始](https://docs.ultralytics.com/platform/quickstart) 开始。如果您需要在 2026 年 7 月底 HUB 下线前迁移现有工作，请创建 Platform 账号，并在 **Settings > Integrations > Ultralytics HUB** 粘贴 HUB API key，以迁移数据集和模型。
+
+- 请使用本仓库的 **Issues** 页面提交旧版 HUB 仓库支持和迁移问题。
+- 访问 [Ultralytics 帮助中心](https://docs.ultralytics.com/help/FAQ) 获取快速答案。
+- 浏览 [Ultralytics 帮助中心](https://docs.ultralytics.com/help) 了解故障排除和最佳实践。
+- 浏览 [Ultralytics Platform 文档](https://docs.ultralytics.com/platform) 了解当前工作流。
+- 加入 [Ultralytics Discord 社区](https://discord.com/invite/ultralytics) 参与实时讨论。
 
 ## 贡献
 
-我们欢迎您的贡献！❤️ 请参阅 [贡献指南](https://docs.ultralytics.com/help/contributing) 了解参与方式。感谢所有为 Ultralytics 生态做出贡献的开发者！
+我们欢迎能够改进旧版迁移支持、澄清 Platform 入门流程或修复仓库示例的贡献。请参阅 [贡献指南](https://docs.ultralytics.com/help/contributing) 了解参与方式。感谢所有贡献者！
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
 <br>
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
-  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%">
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,7 @@
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+
 </div>
 
 来自 [Ultralytics](https://www.ultralytics.com/) 团队的问候。本仓库现在用于为现有 Ultralytics HUB 用户提供旧版支持，帮助他们将数据集、模型和工作流迁移到 [Ultralytics Platform](https://platform.ultralytics.com)。Platform 是端到端计算机视觉平台，覆盖数据准备、标注、YOLO 模型训练、导出、部署和监控。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,7 +75,7 @@ my-dataset.zip
 
 ```bash
 # 压缩数据集目录以便上传
-zip -r my-dataset.zip my-dataset
+cd my-dataset && zip -r ../my-dataset.zip .
 ```
 
 请参考 [example_datasets/coco8.zip](./example_datasets/coco8.zip) 和本地 `example_datasets/` 目录中的小型 YOLO 格式压缩包示例。更多数据集格式说明，请参阅 [Ultralytics 数据集文档](https://docs.ultralytics.com/datasets)。Platform 也支持 COCO JSON 标注、Ultralytics NDJSON 导出、分类文件夹布局、视频，以及用于在线标注的原始未标注图像。


### PR DESCRIPTION
## Summary
- reposition the repository as legacy HUB support while users migrate to Ultralytics Platform
- restore non-HUB language, social, docs, guide, app, and contributor backlinks
- replace HUB-specific badges/screenshots/Colab links with Platform docs imagery and workflow details

## Validation
- git diff --check -- README.md README.zh-CN.md
- rg no longer finds old HUB URLs, Colab links, workflow badge links, or HUB screenshot paths in the root READMEs

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refreshes the `ultralytics/hub` README files to clearly position HUB as a legacy product and guide users toward Ultralytics Platform for future dataset, training, and deployment workflows 🚀

### 📊 Key Changes
- Updated both English and Chinese README files to state that Ultralytics HUB is in deprecation mode and will be wound down by **July 2026** ⚠️
- Reframed this repository as **legacy support only**, with stronger migration guidance for existing HUB users moving datasets and models to **Ultralytics Platform** 🔄
- Expanded Platform documentation in the README to better explain:
  - dataset upload formats and limits
  - annotation and validation features
  - cloud and local training workflows
  - deployment options, monitoring, and export formats 📦
- Added clearer migration instructions using **Settings > Integrations > Ultralytics HUB** and HUB API keys 🔑
- Replaced older visuals and examples with newer Platform-focused banners, screenshots, and workflow examples 🖼️
- Added more practical examples, including updated dataset structure, YAML examples, local training commands, and `ul://` dataset URI usage 💡
- Cleaned up README presentation by removing outdated badges/links like the CI badge and Colab shortcut, and improving accessibility with better image `alt` text ✨
- Updated language links so the Chinese README is now maintained locally in the repo rather than pointing only to docs 🌍

### 🎯 Purpose & Impact
- Helps users quickly understand that **new work should start on Ultralytics Platform**, reducing confusion about HUB’s future direction 🧭
- Makes migration easier for current HUB users by providing clearer steps and support paths before the 2026 shutdown ⏳
- Improves onboarding by turning the README into a more complete Platform quickstart for datasets, training, and deployment 📘
- Better showcases modern Ultralytics capabilities such as YOLO26 support, browser prediction, endpoint deployment, and local-to-cloud workflow integration 🤖
- Likely reduces support burden by answering common questions directly in the README and pointing users to the right docs and issue channels 🙌