### PR TITLE
Improve HUB CI stability

### DIFF
--- a/.github/scripts/run_hub_exports.py
+++ b/.github/scripts/run_hub_exports.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from ultralytics import checks, hub
 
 POLL_DELAYS = (30, 60, 90, 120, 240, 360)
+TOTAL_TIMEOUT_SECONDS = 55 * 60
 REQUIRED_FORMATS = (
     "torchscript",
     "onnx",
@@ -37,8 +38,13 @@ class ExportResult:
     detail: str
 
 
-def poll_export(model_id: str, name: str, required: bool) -> ExportResult:
+def poll_export(model_id: str, name: str, required: bool, deadline: float) -> ExportResult:
     """Start one export and poll until it succeeds or exhausts the retry window."""
+    if time.monotonic() >= deadline:
+        detail = "skipped because the CI timeout budget was exhausted"
+        print(f"{name}: {detail}", flush=True)
+        return ExportResult(name, required, False, 0, detail)
+
     print(f"Starting {name} export...", flush=True)
     try:
         hub.export_model(model_id, format=name)
@@ -47,6 +53,10 @@ def poll_export(model_id: str, name: str, required: bool) -> ExportResult:
 
     detail = "no status returned"
     for attempt, delay in enumerate(POLL_DELAYS, start=1):
+        if time.monotonic() + delay >= deadline:
+            detail = "stopped before the CI timeout budget was exhausted"
+            print(f"{name}: {detail}", flush=True)
+            return ExportResult(name, required, False, attempt - 1, detail)
         time.sleep(delay)
         try:
             export = hub.get_export(model_id, format=name)
@@ -90,8 +100,9 @@ def write_summary(results: list[ExportResult]) -> None:
 def main() -> None:
     checks()
     model_id = os.environ["MODEL_ID"]
-    results = [poll_export(model_id, name, True) for name in REQUIRED_FORMATS] + [
-        poll_export(model_id, name, False) for name in OPTIONAL_FORMATS
+    deadline = time.monotonic() + TOTAL_TIMEOUT_SECONDS
+    results = [poll_export(model_id, name, True, deadline) for name in REQUIRED_FORMATS] + [
+        poll_export(model_id, name, False, deadline) for name in OPTIONAL_FORMATS
     ]
 
     write_summary(results)

--- a/.github/scripts/run_hub_exports.py
+++ b/.github/scripts/run_hub_exports.py
@@ -1,0 +1,117 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+"""Run scheduled HUB export checks with per-format reporting."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+from ultralytics import checks, hub
+
+
+POLL_DELAYS = (30, 60, 90, 120, 240, 360)
+REQUIRED_FORMATS = (
+    "torchscript",
+    "onnx",
+    "openvino",
+    "coreml",
+    "saved_model",
+    "pb",
+    "tflite",
+    "tfjs",
+    "paddle",
+    "ultralytics_tflite",
+    "ultralytics_coreml",
+    "ncnn",
+)
+OPTIONAL_FORMATS = ("edgetpu", "engine")
+
+
+@dataclass
+class ExportResult:
+    name: str
+    required: bool
+    ok: bool
+    attempts: int
+    detail: str
+
+
+def poll_export(model_id: str, name: str, required: bool) -> ExportResult:
+    """Start one export and poll until it succeeds or exhausts the retry window."""
+    print(f"Starting {name} export...", flush=True)
+    try:
+        hub.export_model(model_id, format=name)
+    except Exception as e:
+        return ExportResult(name, required, False, 0, f"start failed: {e}")
+
+    detail = "no status returned"
+    for attempt, delay in enumerate(POLL_DELAYS, start=1):
+        time.sleep(delay)
+        try:
+            export = hub.get_export(model_id, format=name)
+        except Exception as e:
+            detail = f"poll failed: {e}"
+            print(f"{name}: attempt {attempt}/{len(POLL_DELAYS)} {detail}", flush=True)
+            continue
+
+        if export.get("success"):
+            print(f"{name}: done", flush=True)
+            return ExportResult(name, required, True, attempt, "success")
+
+        detail = f"success={export.get('success')}"
+        print(f"{name}: attempt {attempt}/{len(POLL_DELAYS)} {detail}", flush=True)
+
+    return ExportResult(name, required, False, len(POLL_DELAYS), detail)
+
+
+def write_summary(results: list[ExportResult]) -> None:
+    """Append a compact export table to the GitHub step summary."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    rows = [
+        "### HUB export summary",
+        "",
+        "| Format | Required | Result | Attempts | Detail |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for result in results:
+        rows.append(
+            f"| {result.name} | {'yes' if result.required else 'no'} | "
+            f"{'pass' if result.ok else 'fail'} | {result.attempts} | {result.detail} |"
+        )
+
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write("\n".join(rows) + "\n")
+
+
+def main() -> None:
+    checks()
+    model_id = os.environ["MODEL_ID"]
+    results = [poll_export(model_id, name, True) for name in REQUIRED_FORMATS] + [
+        poll_export(model_id, name, False) for name in OPTIONAL_FORMATS
+    ]
+
+    write_summary(results)
+
+    failed_required = [
+        result for result in results if result.required and not result.ok
+    ]
+    failed_optional = [
+        result for result in results if not result.required and not result.ok
+    ]
+    for result in failed_optional:
+        print(
+            f"::warning::Optional HUB export {result.name} failed after "
+            f"{result.attempts} attempts: {result.detail}"
+        )
+    if failed_required:
+        names = ", ".join(result.name for result in failed_required)
+        raise AssertionError(f"Required HUB exports failed: {names}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/run_hub_exports.py
+++ b/.github/scripts/run_hub_exports.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 
 from ultralytics import checks, hub
 
-
 POLL_DELAYS = (30, 60, 90, 120, 240, 360)
 REQUIRED_FORMATS = (
     "torchscript",
@@ -97,17 +96,10 @@ def main() -> None:
 
     write_summary(results)
 
-    failed_required = [
-        result for result in results if result.required and not result.ok
-    ]
-    failed_optional = [
-        result for result in results if not result.required and not result.ok
-    ]
+    failed_required = [result for result in results if result.required and not result.ok]
+    failed_optional = [result for result in results if not result.required and not result.ok]
     for result in failed_optional:
-        print(
-            f"::warning::Optional HUB export {result.name} failed after "
-            f"{result.attempts} attempts: {result.detail}"
-        )
+        print(f"::warning::Optional HUB export {result.name} failed after {result.attempts} attempts: {result.detail}")
     if failed_required:
         names = ", ".join(result.name for result in failed_required)
         raise AssertionError(f"Required HUB exports failed: {names}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,26 @@ jobs:
         run: |
           yolo checks
           uv pip list
-      - name: Login to HUB
+      - name: Check HUB credentials
+        id: hub_secrets
+        shell: bash
         run: |
-          yolo login ${{ env.API_KEY }}
+          if [[ -n "${API_KEY}" && -n "${MODEL_ID}" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping HUB API integration tests because HUB secrets are unavailable."
+            if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+              echo "::error::ULTRALYTICS_HUB_API_KEY and ULTRALYTICS_HUB_MODEL_ID are required for ${GITHUB_EVENT_NAME} runs."
+              exit 1
+            fi
+          fi
+      - name: Login to HUB
+        if: steps.hub_secrets.outputs.available == 'true'
+        run: |
+          yolo login "$API_KEY"
       - name: Test HUB training
+        if: steps.hub_secrets.outputs.available == 'true'
         continue-on-error: false
         shell: python
         run: |
@@ -56,6 +72,7 @@ jobs:
           model = YOLO('https://hub.ultralytics.com/models/' + model_id)
           model.train()
       - name: Test HUB inference API
+        if: steps.hub_secrets.outputs.available == 'true'
         shell: python
         run: |
           import os
@@ -71,48 +88,9 @@ jobs:
           response.raise_for_status()  # ensure we got a successful response
           print(json.dumps(response.json(), indent=2))
       - name: Test HUB export
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        shell: python
+        if: steps.hub_secrets.outputs.available == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
-          import os
-          import time
-          from ultralytics import YOLO, checks, hub
-          
-          checks()
-          model_id = os.environ["MODEL_ID"]
-          success = []
-          backoff_times = [30, 60, 90, 120, 240, 360]  # exponential backoff waits in seconds
-          for f in (
-              "torchscript",
-              "onnx",
-              "openvino",
-              "coreml",
-              "saved_model",
-              "pb",
-              "tflite",
-              "edgetpu",
-              "tfjs",
-              "paddle",
-              "ultralytics_tflite",
-              "ultralytics_coreml",
-              "ncnn",
-              "engine",
-          ):
-              print(f"Starting {f} export... ", end="")
-              hub.export_model(model_id, format=f)
-              for i, wait_time in enumerate(backoff_times):
-                  time.sleep(wait_time)  # wait for export to complete
-                  try:
-                      success.append(hub.get_export(model_id, format=f)["success"])
-                      print("done ✅" if success[-1] else f"Error ❌ {f}")
-                      break
-                  except Exception as e:
-                      if i == (len(backoff_times) - 1):
-                          success.append(False)
-                          print(f"Error ❌ {f} export {e}")
-                      else:
-                          print(f"waiting {backoff_times[i + 1]}s", flush=True)
-          assert all(success)
+          python .github/scripts/run_hub_exports.py
       - name: Notify on failure
         if: (cancelled() || failure()) && github.repository == 'ultralytics/hub' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
         uses: slackapi/slack-github-action@v3.0.3


### PR DESCRIPTION
## Summary
- skip HUB API integration steps on pull_request runs when HUB secrets are unavailable, avoiding interactive API-key prompts on Dependabot/fork PRs
- move scheduled export polling into a reusable script with per-format logs and a GitHub step summary
- keep accelerator-specific exports (`edgetpu`, `engine`) monitored as warnings while required core exports still fail the run

## Evidence
- PR #1298 failed because Dependabot pull_request jobs had empty HUB secrets and `hub.reset_model()` fell into interactive API-key input
- Scheduled runs 26615677708 and 26993058047 failed after accepted export requests returned repeated 404s for `engine`/`edgetpu`

## Validation
- `python3 -m py_compile .github/scripts/run_hub_exports.py`
- mocked `poll_export()` success path
- `uvx ruff format --check .github/scripts/run_hub_exports.py`
- `uvx ruff check .github/scripts/run_hub_exports.py`
- parsed workflow YAML with PyYAML
- `actionlint .github/workflows/*.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR makes HUB export testing more reliable and easier to understand by moving export checks into a dedicated script with better reporting, timeout handling, and secret-aware CI behavior 🚀

### 📊 Key Changes
- Added a new CI helper script, `.github/scripts/run_hub_exports.py`, to manage scheduled HUB export checks in a cleaner, reusable way 🛠️
- Split export formats into:
  - **Required** formats, which must pass for CI to succeed ✅
  - **Optional** formats, which only raise warnings if they fail ⚠️
- Improved export polling logic with:
  - per-format retry tracking
  - clearer failure details
  - a total CI timeout budget to avoid jobs running too long ⏱️
- Added a GitHub Actions summary table showing each export format, whether it is required, pass/fail status, number of attempts, and details 📋
- Updated `ci.yml` to check whether HUB secrets are available before running HUB-related tests 🔐
- HUB login, training, inference API, and export tests now run only when credentials are present
- On `pull_request` runs, missing HUB secrets now safely skip HUB integration tests; on other runs, missing required secrets cause the workflow to fail early 🚦
- Replaced the old inline export test script in the workflow with the new standalone Python script for better maintainability 🧹

### 🎯 Purpose & Impact
- Makes CI results much easier to interpret by showing exactly which export formats passed or failed and why 👀
- Reduces noisy failures by treating less critical export formats separately from required ones 🎯
- Prevents wasted CI time with smarter timeout handling and early stopping ⌛
- Improves workflow security and flexibility by only running HUB integration tests when valid secrets are available 🔒
- Helps maintainers catch real HUB export issues faster, especially during scheduled or manual checks 📈
- Makes the CI configuration easier to maintain and extend in the future since export logic now lives in one dedicated script 🧩