### PR TITLE
Add HUB export script docstrings

### DIFF
--- a/.github/scripts/run_hub_exports.py
+++ b/.github/scripts/run_hub_exports.py
@@ -31,6 +31,8 @@ OPTIONAL_FORMATS = ("edgetpu", "engine")
 
 @dataclass
 class ExportResult:
+    """Result from polling one HUB export format."""
+
     name: str
     required: bool
     ok: bool
@@ -38,7 +40,9 @@ class ExportResult:
     detail: str
 
 
-def poll_export(model_id: str, name: str, required: bool, deadline: float) -> ExportResult:
+def poll_export(
+    model_id: str, name: str, required: bool, deadline: float
+) -> ExportResult:
     """Start one export and poll until it succeeds or exhausts the retry window."""
     if time.monotonic() >= deadline:
         detail = "skipped because the CI timeout budget was exhausted"
@@ -98,19 +102,26 @@ def write_summary(results: list[ExportResult]) -> None:
 
 
 def main() -> None:
+    """Run all HUB export checks and fail when required formats fail."""
     checks()
     model_id = os.environ["MODEL_ID"]
     deadline = time.monotonic() + TOTAL_TIMEOUT_SECONDS
-    results = [poll_export(model_id, name, True, deadline) for name in REQUIRED_FORMATS] + [
-        poll_export(model_id, name, False, deadline) for name in OPTIONAL_FORMATS
-    ]
+    results = [
+        poll_export(model_id, name, True, deadline) for name in REQUIRED_FORMATS
+    ] + [poll_export(model_id, name, False, deadline) for name in OPTIONAL_FORMATS]
 
     write_summary(results)
 
-    failed_required = [result for result in results if result.required and not result.ok]
-    failed_optional = [result for result in results if not result.required and not result.ok]
+    failed_required = [
+        result for result in results if result.required and not result.ok
+    ]
+    failed_optional = [
+        result for result in results if not result.required and not result.ok
+    ]
     for result in failed_optional:
-        print(f"::warning::Optional HUB export {result.name} failed after {result.attempts} attempts: {result.detail}")
+        print(
+            f"::warning::Optional HUB export {result.name} failed after {result.attempts} attempts: {result.detail}"
+        )
     if failed_required:
         names = ", ".join(result.name for result in failed_required)
         raise AssertionError(f"Required HUB exports failed: {names}")

--- a/.github/scripts/run_hub_exports.py
+++ b/.github/scripts/run_hub_exports.py
@@ -40,9 +40,7 @@ class ExportResult:
     detail: str
 
 
-def poll_export(
-    model_id: str, name: str, required: bool, deadline: float
-) -> ExportResult:
+def poll_export(model_id: str, name: str, required: bool, deadline: float) -> ExportResult:
     """Start one export and poll until it succeeds or exhausts the retry window."""
     if time.monotonic() >= deadline:
         detail = "skipped because the CI timeout budget was exhausted"
@@ -106,22 +104,16 @@ def main() -> None:
     checks()
     model_id = os.environ["MODEL_ID"]
     deadline = time.monotonic() + TOTAL_TIMEOUT_SECONDS
-    results = [
-        poll_export(model_id, name, True, deadline) for name in REQUIRED_FORMATS
-    ] + [poll_export(model_id, name, False, deadline) for name in OPTIONAL_FORMATS]
+    results = [poll_export(model_id, name, True, deadline) for name in REQUIRED_FORMATS] + [
+        poll_export(model_id, name, False, deadline) for name in OPTIONAL_FORMATS
+    ]
 
     write_summary(results)
 
-    failed_required = [
-        result for result in results if result.required and not result.ok
-    ]
-    failed_optional = [
-        result for result in results if not result.required and not result.ok
-    ]
+    failed_required = [result for result in results if result.required and not result.ok]
+    failed_optional = [result for result in results if not result.required and not result.ok]
     for result in failed_optional:
-        print(
-            f"::warning::Optional HUB export {result.name} failed after {result.attempts} attempts: {result.detail}"
-        )
+        print(f"::warning::Optional HUB export {result.name} failed after {result.attempts} attempts: {result.detail}")
     if failed_required:
         names = ", ".join(result.name for result in failed_required)
         raise AssertionError(f"Required HUB exports failed: {names}")


### PR DESCRIPTION
## Summary
- add docstrings for the HUB export result dataclass and entrypoint
- run Ruff formatting on the touched script

## Tests
- ruff check --select D .github/scripts/run_hub_exports.py
- ruff check .github/scripts/run_hub_exports.py
- ruff format .github/scripts/run_hub_exports.py
- python -m py_compile .github/scripts/run_hub_exports.py
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR adds small but helpful inline documentation to the HUB export check script, making the code easier to understand and maintain.

### 📊 Key Changes
- Added a docstring to the `ExportResult` dataclass in `.github/scripts/run_hub_exports.py`
  - Clarifies that it stores the result of polling a single HUB export format.
- Added a docstring to the `main()` function
  - Explains that it runs all HUB export checks and fails if any required export format fails.
- No functional logic, behavior, or output was changed
  - This is a documentation-only update.

### 🎯 Purpose & Impact
- Improves code readability for contributors and maintainers 👀
- Makes the script’s intent clearer without needing to trace implementation details
- Helps future development and debugging by documenting key responsibilities 🛠️
- Has no user-facing impact and does not change HUB export behavior ✅