### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ["3.11"]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,7 +22,7 @@ jobs:
   Links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install lychee
         run: |


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates GitHub Actions checkout steps from `actions/checkout@v6` to `actions/checkout@v7` in the CI and link-check workflows.

### 📊 Key Changes
- 🔄 Upgraded `actions/checkout` from `v6` to `v7` in `.github/workflows/ci.yml`
- 🔗 Upgraded `actions/checkout` from `v6` to `v7` in `.github/workflows/links.yml`
- 🛠️ No application code or product features were changed; this is a workflow maintenance update

### 🎯 Purpose & Impact
- ✅ Keeps the repository’s GitHub Actions workflows up to date with the latest checkout action version
- 🔒 May improve security, compatibility, and long-term reliability of CI and link validation jobs
- 🚀 Helps reduce future maintenance issues by aligning automation with newer GitHub Actions versions
- 👀 No direct user-facing impact, but it supports a healthier and more dependable development pipeline