### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ on:
 env:
   API_KEY: ${{ secrets.ULTRALYTICS_HUB_API_KEY }}
   MODEL_ID: ${{ secrets.ULTRALYTICS_HUB_MODEL_ID }}
-  HUB_TEAM_SLACK_ID: ${{ secrets.HUB_TEAM_SLACK_ID }}
 
 jobs:
   Tests:
@@ -98,4 +97,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}
           payload: |
-            text: "<!subteam^${{ secrets.HUB_TEAM_SLACK_ID }}|@hub-team> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"
+            text: "<!subteam^S07NKMNECKH> *${{ github.workflow }}* ❌ `${{ github.repository }}`  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- Scopes the broad `<!channel>` ping down to `@platform-team` to cut company-wide notification noise.
- Retires the deprecated `@hub-team` / `HUB_TEAM_SLACK_ID` secret in favor of `@platform-team`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR simplifies CI failure notifications by removing a Slack team ID secret and replacing it with a fixed, shorter Slack alert message in the GitHub Actions workflow.

### 📊 Key Changes
- Removed the `HUB_TEAM_SLACK_ID` environment variable from `.github/workflows/ci.yml`.
- Updated the Slack notification payload used when GitHub Actions fails.
- Replaced the dynamic Slack subteam reference based on a GitHub secret with a hardcoded Slack subteam ID.
- Simplified the alert message format to a shorter version that includes:
  - the workflow name
  - the repository name
  - a direct link to the failed run

### 🎯 Purpose & Impact
- Reduces configuration complexity ⚙️ by removing one required secret from CI setup.
- Makes failure alerts easier to maintain 🛠️ since the workflow no longer depends on an extra environment variable.
- Produces cleaner, more compact Slack notifications 💬 that still link directly to the failed job.
- Slightly reduces flexibility because the Slack team ID is now hardcoded, so future team changes may require editing the workflow file directly.