### PR TITLE
Update AGENTS.md Core Principles to Delete>Replace>Add tripwires

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,22 +4,22 @@ This file provides guidance to AI coding agents (Claude Code, etc.) when working
 
 ## Core Principles (CRITICAL)
 
-Respecting these principles is critical for every PR.
+**Delete > Replace > Add.** Before writing any change, answer in order: what can I delete? what can I replace? only then, what must I add?
 
-**Less is more. The simplest solution is the best solution.**
+The most common agent failure in this repo is reaching for the locally-safest edit — a new guard, flag, or helper — instead of fixing ownership. These tripwires override that instinct:
 
-The action hierarchy for every change: **Delete > Replace > Add**. The best code change is a deletion. The second best is modifying what exists. Adding new code is the last resort.
+1. **Never guard a symptom — relocate the trigger.** A fix that adds a condition to suppress bad behavior (a staleness check, an is-initialized flag, a skip-first-call guard, a try/except around broken logic) is wrong by default. Find the code path that should own the behavior, move the logic there, and delete the code that got it wrong. Example: a warning fired from stale state; the right fix was not a recency guard — it deleted the stale detection and moved the trigger into the code path that observes the event live.
+2. **Bugfixes are net-negative by default.** A bugfix that adds more lines than it removes needs a one-sentence justification in the PR body naming why deletion and relocation were impossible.
+3. **Search before creating anything.** This repo is small — workflows in `.github/workflows/`, one export script in `.github/scripts/`, two mirrored READMEs, and sample datasets. Before adding a workflow, step, or script, check whether the behavior already exists here or is already owned by the shared `ultralytics/actions` workflows (formatting, labeling, spelling, link-checking); reuse it instead of reimplementing. Avoid premature abstraction — three similar lines beat a helper nobody else calls.
+4. **Deletion beats caution.** Zero regression means understanding the code you remove, not leaving it in place as insurance. Keeping broken or duplicated code "to be safe" is itself the regression: it is how repos rot. All changes must still ship debugged, validated, and production ready.
 
-1. **Minimal**: The simplest solution that works. Do not over-engineer, over-abstract, or add code just in case. Three similar lines beat a premature abstraction. Avoid error handling for impossible states, feature flags, compatibility shims, or policy scaffolding unless they are truly required.
-2. **Solve at the source**: Do not hack fixes. Solve problems at their root. If something is broken, fix or remove the broken thing. Never patch over a broken abstraction, add workarounds, or add synchronization code for state that should not be duplicated.
-3. **Delete ruthlessly**: When replacing code, delete what it replaced. Remove unused imports, functions, types, files, and commented-out code. Git preserves history. Run the repo's relevant dead-code or cleanup check when available.
-4. **Replace > Add**: Modify existing code over adding new code. Edit existing files, extend existing components or functions with minimal parameters, and reuse existing utilities. If creating a new file, first prove it cannot fit cleanly in an existing file.
-5. **Check existing**: Search the entire repo before creating anything new. If a feature, component, helper, responder, workflow, or utility already solves a similar problem, reuse or adapt it and delete the duplicate path.
-6. **Deduplicate**: Do not duplicate existing code when updating the repo. Consolidate or refactor duplicates you find when it is in scope and low risk.
-7. **Zero Regression**: Do not break existing features or workflows unless the PR intentionally removes them with evidence.
-8. **Production ready**: All changes must be thoroughly debugged, validated, and production ready.
+**Output gate:** every PR body must contain a `Deleted:` line naming the code removed (functions, branches, files, config). Features must name what they reused or consolidated. `Deleted: nothing` demands the rule-2 justification.
 
-**When fixing bugs, ask: "What can I delete?" before "What can I replace?" before "What should I add?"**
+**Review gate:** adversarial reviewers must answer two questions before LGTM: (a) what could have been deleted instead of added? (b) does any added condition suppress a symptom rather than relocate a trigger? A finding on either blocks LGTM.
+
+**This file is code — additions require deletions.** To add a rule here, remove or merge one. When everything is emphasized, nothing is.
+
+**NEVER push to `main`. NEVER force push.** Always start work in a new git worktree (`git worktree add`) on a feature branch and open a PR — never edit the primary checkout directly, it may hold in-flight work.
 
 ## PR Workflow
 


### PR DESCRIPTION
## Summary

Replaces the AGENTS.md "Core Principles (CRITICAL)" section (added in #1310) with the sharper **Delete > Replace > Add** tripwire framing used across the Ultralytics org rollout. The other sections (PR Workflow, Commands, Architecture, Conventions) are unchanged and were re-verified against the repo.

Key changes to the section:
- Leads with the ordered question "what can I delete? what can I replace? what must I add?"
- Adds the four tripwire rules (relocate the trigger, bugfixes net-negative, search before creating, deletion beats caution), an Output gate requiring a `Deleted:` line in every PR body, and a Review gate for adversarial reviewers.
- Rule 3 is adapted to this small repo (workflows in `.github/workflows/`, one export script in `.github/scripts/`, two mirrored READMEs, sample datasets) rather than naming a shared-utility package that does not exist here.

## Verification

Re-verified every factual claim in the unchanged sections against the repo:
- Install / `yolo checks` / `yolo login` / `run_hub_exports.py` match `.github/workflows/ci.yml`; the export script reads `MODEL_ID` from the environment.
- The lint/format commands match `ultralytics/actions` `action.yml` exactly (`ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore ... .` and `ruff format --line-length 120 .`).
- CI matrix (ubuntu-latest, Python 3.11), cron schedules, secret gating, Slack alert conditions, dependabot monthly interval, and the two-README mirror rule all match the workflow files.

## README audit

Audited `README.md` and `README.zh-CN.md` for drift: both mirror each other on all load-bearing facts (`ultralytics>=8.4.83` matching `requirements.txt`, the end-of-July-2026 deprecation date, `yolo26n`, `ul://` dataset URIs, the API-key env var). No inaccuracies found, so no README changes were needed.

Deleted: the previous "Less is more" Core Principles subsection of AGENTS.md — the intro line, the 8 numbered principles (Minimal/Solve at the source/Delete ruthlessly/Replace/Check existing/Deduplicate/Zero Regression/Production ready), and the closing "What can I delete?" line — replaced by the tripwire rules plus Output/Review gates (net 0 line change; a section rewrite, not an addition).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates `AGENTS.md` with stricter AI-agent contribution rules that prioritize deleting and reusing existing code over adding new code 🧹

### 📊 Key Changes
- Replaces the previous broad “less is more” principles with sharper guidance: **Delete > Replace > Add**.
- Adds explicit “tripwires” to prevent common agent mistakes, such as adding guards, flags, or helpers instead of fixing the root cause.
- Introduces a required PR body `Deleted:` line to document what code, config, or files were removed.
- Adds a review gate requiring reviewers to check whether code could have been deleted instead of added.
- Clarifies that changes to `AGENTS.md` itself must also remove or merge existing guidance.
- Adds strict workflow safety rules: never push to `main`, never force push, and always work from a new `git worktree` feature branch.

### 🎯 Purpose & Impact
- Encourages smaller, cleaner PRs by making deletion and consolidation the default approach ✂️
- Helps prevent repository bloat from unnecessary helpers, duplicated workflows, or defensive patches.
- Improves review quality by giving maintainers clear checks for over-engineering and symptom-masking fixes.
- Reduces risk to shared work by reinforcing safer Git practices and branch-based PR workflows.
- Makes expectations for AI coding agents more concrete, enforceable, and aligned with long-term maintainability 🚀