### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install requirements
         run: |
           uv pip install --system ultralytics hub-sdk --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary
- replace all 1 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 1 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates CI to use Ultralytics’ shared `setup-uv` action for simpler and more consistent Python environment setup. ⚙️

### 📊 Key Changes
- Replaces `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main`.
- Removes the disabled `enable-cache: false` configuration.
- Keeps the existing installation of `ultralytics` and `hub-sdk` using CPU-only PyTorch packages.

### 🎯 Purpose & Impact
- ✅ Standardizes CI setup with Ultralytics’ shared workflow tooling.
- 🧰 Reduces local workflow configuration and maintenance.
- 🚀 Helps improve consistency across repositories without changing the tested dependencies or CI behavior.