### PR TITLE
Point banner link to YOLO Vision 2026 registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com/ultralytics/yolo26?utm_source=github&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=platform_readme" target="_blank">
+    <a href="https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
   </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com/ultralytics/yolo26?utm_source=github&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=platform_readme" target="_blank">
+    <a href="https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
   </p>
 


### PR DESCRIPTION
The YOLO Vision 2026 "Register now" banner (image swapped in ultralytics/assets#184) is embedded here, but the click still went to the Platform or a generic link. This repoints only the banner's link to the YOLO Vision 2026 event page so the clickable banner matches its call to action.

Only the link wrapping the banner image is changed; all other links are untouched. Banner image is unchanged (swapped in-place via the assets repo).

Deleted: nothing — a one-line link correction; the previous URL is replaced, nothing to relocate or remove.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the README banner destination to the YOLO Vision 2026 registration page.

### 📊 Key Changes
- Replaced the platform launch link in `README.md` with the YOLO Vision event registration link.
- Applied the same link update to `README.zh-CN.md`.
- Preserved the existing banner image and tracking parameters for campaign attribution.

### 🎯 Purpose & Impact
- Directs English and Chinese README visitors to register for YOLO Vision 2026.
- Keeps banner behavior consistent across both README files.
- Improves event promotion while retaining link analytics.