### PR TITLE
Restore branded Platform showcase in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Platform is the direct replacement for HUB—and a major upgrade. Create your wo
 
 For current product help and feedback, use the **Help** page inside Platform, explore the [Platform documentation](https://docs.ultralytics.com/platform), or join the [Ultralytics community](https://community.ultralytics.com/). This repository remains available as a historical reference for HUB.
 
+[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
+
 <br>
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://platform.ultralytics.com" target="_blank">
-    <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics Platform">
+    <img width="320" src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" alt="Ultralytics">
   </a>
 
 # Ultralytics HUB is now Ultralytics Platform 🚀

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Meet the new **Ultralytics Platform**—the faster, more powerful home for the entire computer vision lifecycle. Go from raw images to production endpoints in one beautiful workspace, with a meaningful **Free plan** that makes advanced computer vision accessible to everyone.
 
 <p align="center">
-  <a href="https://platform.ultralytics.com"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif" alt="Ultralytics Platform dataset workspace"></a>
+  <a href="https://platform.ultralytics.com"><img width="100%" src="https://cdn.ul.run/i/2990f4be3ba5e24b885f6a1ea278a793.avif" alt="Ultralytics Platform dataset workspace"></a>
 </p>
 
 ## ✨ Annotate
@@ -28,7 +28,7 @@ Meet the new **Ultralytics Platform**—the faster, more powerful home for the e
 Turn raw data into training-ready datasets without leaving your browser. Draw boxes, polygons, keypoints, and oriented boxes—or accelerate labeling with Smart Annotation powered by SAM and YOLO models.
 
 <p align="center">
-  <a href="https://docs.ultralytics.com/platform/data/annotation"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-annotate-editor-toolbar-with-canvas.avif" alt="Ultralytics Platform annotation editor"></a>
+  <a href="https://docs.ultralytics.com/platform/data/annotation"><img width="100%" src="https://cdn.ul.run/i/fd13a4b1f4b8fad9ed5e736030a070cf.avif" alt="Ultralytics Platform annotation editor"></a>
 </p>
 
 ## 🚀 Train
@@ -36,7 +36,7 @@ Turn raw data into training-ready datasets without leaving your browser. Draw bo
 Launch cloud training in a few clicks or connect your own hardware. Compare experiments, stream live metrics and logs, and keep every model organized inside collaborative projects.
 
 <p align="center">
-  <a href="https://docs.ultralytics.com/platform/train"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-train-overview.avif" alt="Ultralytics Platform model training"></a>
+  <a href="https://docs.ultralytics.com/platform/train"><img width="100%" src="https://cdn.ul.run/i/4ec82b7ca5d7c33caab98e08da93ea05.avif" alt="Ultralytics Platform model training"></a>
 </p>
 
 ## 🌍 Deploy
@@ -44,7 +44,7 @@ Launch cloud training in a few clicks or connect your own hardware. Compare expe
 Test predictions in the browser, export models for production, and launch monitored inference endpoints worldwide. Move from trained weights to a live API without building the infrastructure yourself.
 
 <p align="center">
-  <a href="https://docs.ultralytics.com/platform/deploy"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/deploy-page-world-map-with-overview-cards.avif" alt="Ultralytics Platform deployment dashboard"></a>
+  <a href="https://docs.ultralytics.com/platform/deploy"><img width="100%" src="https://cdn.ul.run/i/e922afb2e2f7573c320821ec4fa62537.avif" alt="Ultralytics Platform deployment dashboard"></a>
 </p>
 
 ## 🆓 Start Building for Free

--- a/README.md
+++ b/README.md
@@ -1,49 +1,77 @@
 <div align="center">
-  <a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+  <a href="https://platform.ultralytics.com" target="_blank">
+    <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics Platform">
+  </a>
 
-# Ultralytics HUB (Deprecated)
+# Ultralytics HUB is now Ultralytics Platform 🚀
 
-[中文](README.zh-CN.md) | [Platform Docs](https://docs.ultralytics.com/platform) | [Platform](https://platform.ultralytics.com)
+[中文](README.zh-CN.md) | [한국어](https://docs.ultralytics.com/ko/platform) | [日本語](https://docs.ultralytics.com/ja/platform) | [Русский](https://docs.ultralytics.com/ru/platform) | [Deutsch](https://docs.ultralytics.com/de/platform) | [Français](https://docs.ultralytics.com/fr/platform) | [Español](https://docs.ultralytics.com/es/platform) | [Português](https://docs.ultralytics.com/pt/platform) | [العربية](https://docs.ultralytics.com/ar/platform)
+
+[![Open Ultralytics Platform](https://img.shields.io/badge/Open-Ultralytics_Platform-111F68?logo=ultralytics&logoColor=white)](https://platform.ultralytics.com)
+[![Platform Docs](https://img.shields.io/badge/Read-Platform_Docs-00AEEF?logo=readthedocs&logoColor=white)](https://docs.ultralytics.com/platform)
+[![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.com/invite/ultralytics)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 
 </div>
 
-> [!WARNING]
-> Ultralytics HUB was deprecated and shut down on July 31, 2026. It has been fully replaced by [Ultralytics Platform](https://platform.ultralytics.com). The managed HUB-to-Platform migration was completed during Q2 2026 before the HUB shutdown.
+> [!IMPORTANT]
+> Ultralytics HUB shut down on July 31, 2026, after the managed HUB-to-Platform migration completed successfully during Q2 2026. Your migrated work now lives in [Ultralytics Platform](https://platform.ultralytics.com). Legacy HUB APIs and API keys no longer work.
 
-Legacy HUB API keys do not work with Platform. Sign in to your migrated Platform account—or create one if you are new—then create a new Platform API key for current training, inference, and automation workflows.
+Meet the new **Ultralytics Platform**—the faster, more powerful home for the entire computer vision lifecycle. Go from raw images to production endpoints in one beautiful workspace, with a meaningful **Free plan** that makes advanced computer vision accessible to everyone.
 
-## A More Capable Platform, Free to Start
+<p align="center">
+  <a href="https://platform.ultralytics.com"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif" alt="Ultralytics Platform dataset workspace"></a>
+</p>
 
-Ultralytics Platform is the direct replacement for HUB and delivers a substantially more capable workflow in one workspace. A meaningful Free plan lets individuals get started, while [Platform pricing](https://www.ultralytics.com/pricing) remains the source of truth for current limits and optional usage-based credits.
+## ✨ Annotate
 
-| Capability | Ultralytics Platform improvement                                                                                      |
-| ---------- | --------------------------------------------------------------------------------------------------------------------- |
-| Data       | Upload and validate rich computer vision datasets with built-in statistics and workspace organization                 |
-| Annotation | Label supported YOLO annotation task types with dedicated tools and Smart Annotation powered by SAM and YOLO models   |
-| Training   | Train on cloud GPUs or your own hardware while streaming metrics, logs, and system statistics into organized projects |
-| Models     | Test predictions in the browser and export models to supported deployment formats                                     |
-| Deployment | Launch and monitor dedicated inference endpoints                                                                      |
-| Automation | Use workspace-scoped Platform API keys and the REST API for datasets, models, training, exports, and deployments      |
+Turn raw data into training-ready datasets without leaving your browser. Draw boxes, polygons, keypoints, and oriented boxes—or accelerate labeling with Smart Annotation powered by SAM and YOLO models.
 
-## Move to Ultralytics Platform
+<p align="center">
+  <a href="https://docs.ultralytics.com/platform/data/annotation"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-annotate-editor-toolbar-with-canvas.avif" alt="Ultralytics Platform annotation editor"></a>
+</p>
 
-[Ultralytics Platform](https://platform.ultralytics.com) provides the current end-to-end workflow for dataset management and annotation, cloud and remote training, model export, dedicated inference endpoints, and deployment monitoring.
+## 🚀 Train
 
-1. Sign in to your migrated Platform account, or follow the [Platform quickstart](https://docs.ultralytics.com/platform/quickstart) to create one if you are new.
-2. Add new work and any local dataset or model copies directly to Platform. The managed HUB migration concluded in Q2 2026.
-3. Create a new key under **Settings > API Keys** and follow the [Platform API key guide](https://docs.ultralytics.com/platform/account/api-keys).
-4. Use the [Platform REST API](https://docs.ultralytics.com/platform/api) for programmatic access.
+Launch cloud training in a few clicks or connect your own hardware. Compare experiments, stream live metrics and logs, and keep every model organized inside collaborative projects.
 
-Current Platform resources:
+<p align="center">
+  <a href="https://docs.ultralytics.com/platform/train"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-train-overview.avif" alt="Ultralytics Platform model training"></a>
+</p>
 
-- [Platform overview](https://docs.ultralytics.com/platform)
-- [Dataset upload and management](https://docs.ultralytics.com/platform/data/datasets)
-- [Annotation](https://docs.ultralytics.com/platform/data/annotation)
-- [Cloud and remote training](https://docs.ultralytics.com/platform/train/cloud-training)
-- [Model export and deployment](https://docs.ultralytics.com/platform/deploy)
-- [REST API reference](https://docs.ultralytics.com/platform/api)
-- [Free, Pro, and Enterprise plans](https://www.ultralytics.com/plans)
+## 🌍 Deploy
 
-## Repository Status
+Test predictions in the browser, export models for production, and launch monitored inference endpoints worldwide. Move from trained weights to a live API without building the infrastructure yourself.
 
-This repository is retained as a historical reference only. HUB services cannot be restored through repository issues or pull requests, and new HUB features are not accepted. For current product help and feedback, use the **Help** page in [Ultralytics Platform](https://platform.ultralytics.com), the [Platform documentation](https://docs.ultralytics.com/platform), or the [Ultralytics community forum](https://community.ultralytics.com/).
+<p align="center">
+  <a href="https://docs.ultralytics.com/platform/deploy"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/deploy-page-world-map-with-overview-cards.avif" alt="Ultralytics Platform deployment dashboard"></a>
+</p>
+
+## 🆓 Start Building for Free
+
+Platform is the direct replacement for HUB—and a major upgrade. Create your workspace, explore the complete workflow, and see current Free, Pro, and Enterprise options on the [Platform pricing page](https://www.ultralytics.com/pricing).
+
+<div align="center">
+
+### [Start with Ultralytics Platform →](https://platform.ultralytics.com)
+
+</div>
+
+## 💬 Help and Community
+
+For current product help and feedback, use the **Help** page inside Platform, explore the [Platform documentation](https://docs.ultralytics.com/platform), or join the [Ultralytics community](https://community.ultralytics.com/). This repository remains available as a historical reference for HUB.
+
+<br>
+<div align="center">
+  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics X"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,49 +1,74 @@
 <div align="center">
-  <a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+  <a href="https://platform.ultralytics.com" target="_blank">
+    <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics Platform">
+  </a>
 
-# Ultralytics HUB（已停用）
+# Ultralytics HUB 现已升级为 Ultralytics Platform 🚀
 
-[English](README.md) | [Platform 文档](https://docs.ultralytics.com/zh/platform) | [Platform](https://platform.ultralytics.com)
+[English](README.md) | [한국어](https://docs.ultralytics.com/ko/platform) | [日本語](https://docs.ultralytics.com/ja/platform) | [Русский](https://docs.ultralytics.com/ru/platform) | [Deutsch](https://docs.ultralytics.com/de/platform) | [Français](https://docs.ultralytics.com/fr/platform) | [Español](https://docs.ultralytics.com/es/platform) | [Português](https://docs.ultralytics.com/pt/platform) | [العربية](https://docs.ultralytics.com/ar/platform)
+
+[![打开 Ultralytics Platform](https://img.shields.io/badge/打开-Ultralytics_Platform-111F68?logo=ultralytics&logoColor=white)](https://platform.ultralytics.com)
+[![Platform 文档](https://img.shields.io/badge/阅读-Platform_文档-00AEEF?logo=readthedocs&logoColor=white)](https://docs.ultralytics.com/zh/platform)
+[![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.com/invite/ultralytics)
 
 </div>
 
-> [!WARNING]
-> Ultralytics HUB 已于 2026 年 7 月 31 日停用并关闭，现已由 [Ultralytics Platform](https://platform.ultralytics.com) 全面取代。HUB 到 Platform 的托管迁移已于 2026 年第二季度在 HUB 关闭前完成。
+> [!IMPORTANT]
+> Ultralytics HUB 已于 2026 年 7 月 31 日关闭。在此之前，托管的 HUB 到 Platform 迁移已于 2026 年第二季度顺利完成。迁移后的内容现已位于 [Ultralytics Platform](https://platform.ultralytics.com)；旧版 HUB API 和 API key 已停止工作。
 
-旧版 HUB API key 无法用于 Platform。请登录已迁移的 Platform 账号；新用户可创建账号。然后创建新的 Platform API key，以使用当前的训练、推理和自动化工作流。
+欢迎使用全新的 **Ultralytics Platform**——覆盖完整计算机视觉生命周期的更快、更强大的一站式平台。通过一个精美的工作区，将原始图像转化为生产级推理端点；实用的 **Free 方案**让每个人都能轻松开始。
 
-## 功能更强大，免费开始使用
+<p align="center">
+  <a href="https://platform.ultralytics.com"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif" alt="Ultralytics Platform 数据集工作区"></a>
+</p>
 
-Ultralytics Platform 是 HUB 的直接替代产品，在统一工作区中提供功能显著增强的工作流。个人用户可通过实用的 Free 方案开始使用；当前方案限制和可选的按量 credits 请以 [Platform 定价](https://www.ultralytics.com/pricing)为准。
+## ✨ 标注
 
-| 功能   | Ultralytics Platform 提升                                                                                   |
-| ------ | ----------------------------------------------------------------------------------------------------------- |
-| 数据   | 上传并校验丰富的计算机视觉数据集，使用内置统计信息和工作区进行组织                                          |
-| 标注   | 使用专用工具标注 Platform 支持的 YOLO 标注任务类型，并通过 SAM 和 YOLO 模型驱动的 Smart Annotation 提升效率 |
-| 训练   | 使用云端 GPU 或自有硬件训练，并在项目中实时同步指标、日志和系统统计信息                                     |
-| 模型   | 在浏览器中测试预测，并将模型导出为支持的部署格式                                                            |
-| 部署   | 启动并监控专用推理端点                                                                                      |
-| 自动化 | 使用 workspace-scoped Platform API key 和 REST API 管理数据集、模型、训练、导出与部署                       |
+直接在浏览器中将原始数据转化为可训练的数据集。绘制边界框、多边形、关键点和旋转框，或使用由 SAM 和 YOLO 模型驱动的 Smart Annotation 加速标注。
 
-## 转向 Ultralytics Platform
+<p align="center">
+  <a href="https://docs.ultralytics.com/zh/platform/data/annotation"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-annotate-editor-toolbar-with-canvas.avif" alt="Ultralytics Platform 标注编辑器"></a>
+</p>
 
-[Ultralytics Platform](https://platform.ultralytics.com) 提供当前端到端工作流，包括数据集管理和标注、云端与远程训练、模型导出、专用推理端点和部署监控。
+## 🚀 训练
 
-1. 登录已迁移的 Platform 账号；新用户可按照 [Platform 快速开始](https://docs.ultralytics.com/zh/platform/quickstart) 创建账号。
-2. 将新工作以及本地保存的数据集或模型直接添加到 Platform。HUB 托管迁移已于 2026 年第二季度完成。
-3. 在 **Settings > API Keys** 中创建新 key，并参阅 [Platform API key 指南](https://docs.ultralytics.com/zh/platform/account/api-keys)。
-4. 使用 [Platform REST API](https://docs.ultralytics.com/zh/platform/api) 进行编程访问。
+只需点击几下即可启动云端训练，也可连接自有硬件。比较实验、实时查看指标与日志，并在协作项目中有序管理每个模型。
 
-当前 Platform 资源：
+<p align="center">
+  <a href="https://docs.ultralytics.com/zh/platform/train"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-train-overview.avif" alt="Ultralytics Platform 模型训练"></a>
+</p>
 
-- [Platform 概览](https://docs.ultralytics.com/zh/platform)
-- [数据集上传和管理](https://docs.ultralytics.com/zh/platform/data/datasets)
-- [数据标注](https://docs.ultralytics.com/zh/platform/data/annotation)
-- [云端与远程训练](https://docs.ultralytics.com/zh/platform/train/cloud-training)
-- [模型导出与部署](https://docs.ultralytics.com/zh/platform/deploy)
-- [REST API 参考](https://docs.ultralytics.com/zh/platform/api)
-- [Free、Pro 和 Enterprise 方案](https://www.ultralytics.com/plans)
+## 🌍 部署
 
-## 仓库状态
+在浏览器中测试预测、将模型导出到生产环境，并在全球启动带监控的推理端点。无需自行搭建基础设施，即可从训练权重快速获得在线 API。
 
-本仓库仅作为历史参考保留。HUB 服务无法通过仓库 issue 或 pull request 恢复，也不再接受新的 HUB 功能。当前产品帮助和反馈请使用 [Ultralytics Platform](https://platform.ultralytics.com) 中的 **Help** 页面、[Platform 文档](https://docs.ultralytics.com/zh/platform) 或 [Ultralytics 社区论坛](https://community.ultralytics.com/)。
+<p align="center">
+  <a href="https://docs.ultralytics.com/zh/platform/deploy"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/deploy-page-world-map-with-overview-cards.avif" alt="Ultralytics Platform 部署仪表板"></a>
+</p>
+
+## 🆓 免费开始构建
+
+Platform 是 HUB 的直接替代产品，也是一次重大升级。立即创建工作区、体验完整流程，并在 [Platform 定价页面](https://www.ultralytics.com/pricing)查看当前方案。
+
+<div align="center">
+
+### [开始使用 Ultralytics Platform →](https://platform.ultralytics.com)
+
+</div>
+
+## 💬 帮助与社区
+
+如需当前产品帮助或提交反馈，请使用 Platform 内的 **Help** 页面、浏览 [Platform 文档](https://docs.ultralytics.com/zh/platform)，或加入 [Ultralytics 社区](https://community.ultralytics.com/)。本仓库仅作为 HUB 的历史参考保留。
+
+<br>
+<div align="center">
+  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics X"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://platform.ultralytics.com" target="_blank">
-    <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics Platform">
+    <img width="320" src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" alt="Ultralytics">
   </a>
 
 # Ultralytics HUB 现已升级为 Ultralytics Platform 🚀

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,6 +60,8 @@ Platform 是 HUB 的直接替代产品，也是一次重大升级。立即创建
 
 如需当前产品帮助或提交反馈，请使用 Platform 内的 **Help** 页面、浏览 [Platform 文档](https://docs.ultralytics.com/zh/platform)，或加入 [Ultralytics 社区](https://community.ultralytics.com/)。本仓库仅作为 HUB 的历史参考保留。
 
+[![Ultralytics 开源贡献者](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
+
 <br>
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@
 欢迎使用全新的 **Ultralytics Platform**——覆盖完整计算机视觉生命周期的更快、更强大的一站式平台。通过一个精美的工作区，将原始图像转化为生产级推理端点；实用的 **Free 方案**让每个人都能轻松开始。
 
 <p align="center">
-  <a href="https://platform.ultralytics.com"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/dataset-screenshot.avif" alt="Ultralytics Platform 数据集工作区"></a>
+  <a href="https://platform.ultralytics.com"><img width="100%" src="https://cdn.ul.run/i/2990f4be3ba5e24b885f6a1ea278a793.avif" alt="Ultralytics Platform 数据集工作区"></a>
 </p>
 
 ## ✨ 标注
@@ -27,7 +27,7 @@
 直接在浏览器中将原始数据转化为可训练的数据集。绘制边界框、多边形、关键点和旋转框，或使用由 SAM 和 YOLO 模型驱动的 Smart Annotation 加速标注。
 
 <p align="center">
-  <a href="https://docs.ultralytics.com/zh/platform/data/annotation"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-annotate-editor-toolbar-with-canvas.avif" alt="Ultralytics Platform 标注编辑器"></a>
+  <a href="https://docs.ultralytics.com/zh/platform/data/annotation"><img width="100%" src="https://cdn.ul.run/i/fd13a4b1f4b8fad9ed5e736030a070cf.avif" alt="Ultralytics Platform 标注编辑器"></a>
 </p>
 
 ## 🚀 训练
@@ -35,7 +35,7 @@
 只需点击几下即可启动云端训练，也可连接自有硬件。比较实验、实时查看指标与日志，并在协作项目中有序管理每个模型。
 
 <p align="center">
-  <a href="https://docs.ultralytics.com/zh/platform/train"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/platform-train-overview.avif" alt="Ultralytics Platform 模型训练"></a>
+  <a href="https://docs.ultralytics.com/zh/platform/train"><img width="100%" src="https://cdn.ul.run/i/4ec82b7ca5d7c33caab98e08da93ea05.avif" alt="Ultralytics Platform 模型训练"></a>
 </p>
 
 ## 🌍 部署
@@ -43,7 +43,7 @@
 在浏览器中测试预测、将模型导出到生产环境，并在全球启动带监控的推理端点。无需自行搭建基础设施，即可从训练权重快速获得在线 API。
 
 <p align="center">
-  <a href="https://docs.ultralytics.com/zh/platform/deploy"><img width="100%" src="https://cdn.jsdelivr.net/gh/ultralytics/assets@main/docs/platform/deploy-page-world-map-with-overview-cards.avif" alt="Ultralytics Platform 部署仪表板"></a>
+  <a href="https://docs.ultralytics.com/zh/platform/deploy"><img width="100%" src="https://cdn.ul.run/i/e922afb2e2f7573c320821ec4fa62537.avif" alt="Ultralytics Platform 部署仪表板"></a>
 </p>
 
 ## 🆓 免费开始构建


### PR DESCRIPTION
## Summary

Restore the Ultralytics visual identity and turn the HUB shutdown README into a concise, image-led Platform showcase instead of a documentation-style notice.

- Restore the full-width Ultralytics banner, badges, multilingual navigation, emojis, visual hierarchy, CTAs, and social footer.
- Lead with Platform's value, meaningful Free plan, and a direct **Start with Ultralytics Platform** action.
- Add simple **Annotate**, **Train**, and **Deploy** sections with current screenshots sourced from the existing Platform documentation assets.
- Keep the shutdown and completed Q2 2026 migration facts in one compact warning without letting them dominate the page.
- Apply the same branded experience to the English and Chinese READMEs.

Deleted: the sterile capability table, documentation-heavy transition steps, and text-only presentation that replaced the repository's established branding.

## Validation

- Prettier 3.8.5
- Codespell
- `git diff --check`
- HTTP 200 verification for all four Platform screenshot assets

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📢 Rebrands the HUB repository as a historical reference and directs users to the feature-rich Ultralytics Platform for annotation, training, and deployment.

### 📊 Key Changes

- Updates the English and Chinese READMEs to present **Ultralytics Platform** as the successor to HUB.
- Clarifies that HUB shut down on July 31, 2026, and that legacy HUB APIs and API keys no longer work.
- Adds Platform-focused descriptions for:
  - Browser-based annotation with Smart Annotation powered by SAM and YOLO models.
  - Cloud or remote training with experiment tracking and live metrics.
  - Model testing, export, and monitored inference endpoint deployment.
- Adds prominent links, badges, screenshots, translated documentation links, pricing information, and community resources.
- Removes legacy migration instructions and detailed HUB capability tables in favor of a concise Platform introduction.

### 🎯 Purpose & Impact

- 🚀 Helps former HUB users transition to the current [Ultralytics Platform](https://platform.ultralytics.com) and find relevant documentation quickly.
- 🧭 Makes the repository’s status and the end of legacy HUB API support clear.
- 🛠️ Highlights an end-to-end computer vision workflow for data preparation, training, and deployment.
- 🌍 Improves discoverability through multilingual links, visual examples, and community support channels.
- 📚 Establishes the repository as historical documentation rather than an active location for HUB support or development.