### PR TITLE
Add License section to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ For current product help and feedback, use the **Help** page inside Platform, ex
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
+## 📄 License
+
+Ultralytics offers two licensing options to accommodate diverse needs:
+
+- **AGPL-3.0 License**: Ideal for students, researchers, and enthusiasts passionate about open collaboration and knowledge sharing. This [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license promotes transparency and community involvement. See the [LICENSE](LICENSE) file for details.
+- **Enterprise License**: Designed for commercial applications, this license permits the seamless integration of Ultralytics software and AI models into commercial products and services, bypassing the copyleft requirements of AGPL-3.0. For commercial use cases, please inquire about an [Ultralytics Enterprise License](https://www.ultralytics.com/license).
+
 <br>
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,6 +62,13 @@ Platform 是 HUB 的直接替代产品，也是一次重大升级。立即创建
 
 [![Ultralytics 开源贡献者](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
+## 📄 许可证
+
+Ultralytics 提供两种许可证选项，以适配不同使用场景：
+
+- **AGPL-3.0 许可证**：这是一个经 [OSI 批准](https://opensource.org/license/agpl-3.0)的开源许可证，非常适合重视开放协作与知识共享的学生、研究人员和爱好者。详情请参阅 [LICENSE](LICENSE) 文件。
+- **Ultralytics 企业许可证**：适用于商业用途，允许将 Ultralytics 软件和 AI 模型无缝集成到商业产品与服务中，而无需遵循 AGPL-3.0 的开源要求。如需商业授权，请通过 [Ultralytics 授权许可](https://www.ultralytics.com/license)与我们联系。
+
 <br>
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>


### PR DESCRIPTION
This repo ships an AGPL-3.0 `LICENSE` file, but neither README mentioned it or linked to it. Added the canonical two-option `## 📄 License` section to `README.md` and `README.zh-CN.md`.

No other structural changes: this is a historical Platform redirect page, so the existing HUB shutdown notice, Platform sections, and Help and Community section are untouched, and no Contribute section was added — the README already states that all current work belongs on Platform.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📄 Adds clear AGPL-3.0 and Enterprise licensing information to the English and Chinese README files.

### 📊 Key Changes

- Added a new **License** section to `README.md`.
- Added the equivalent **许可证** section to `README.zh-CN.md`.
- Explained that:
  - **AGPL-3.0** supports open-source, educational, research, and community use.
  - **Enterprise licensing** supports commercial integration without AGPL-3.0 copyleft requirements.
- Included links to the AGPL-3.0 license, repository `LICENSE` file, and [Ultralytics Enterprise licensing](https://www.ultralytics.com/license).

### 🎯 Purpose & Impact

- ✅ Makes licensing options easier to find for both English- and Chinese-speaking users.
- 💼 Clarifies the appropriate licensing path for commercial applications.
- 🤝 Helps students, researchers, enthusiasts, and businesses understand how they can use Ultralytics software and AI models.