### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,98 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+name: 🐛 Bug Report
+# title: " "
+description: Problems with Ultralytics HUB
+labels: [bug, triage]
+type: "bug"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting an Ultralytics 🐛 Bug Report!
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please search the [Platform docs](https://docs.ultralytics.com/platform/) and [issues](https://github.com/ultralytics/hub/issues) to see if a similar bug report already exists.
+      options:
+        - label: >
+            I have searched the Ultralytics [issues](https://github.com/ultralytics/hub/issues) and found no similar bug report.
+          required: true
+
+  - type: dropdown
+    attributes:
+      label: Ultralytics Component
+      description: |
+        Please select the component where you found the bug.
+      multiple: true
+      options:
+        - "Sign in and account"
+        - "Datasets"
+        - "Projects"
+        - "Models"
+        - "Cloud training"
+        - "Inference API"
+        - "Integrations"
+        - "Documentation"
+        - "Other"
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Bug
+      description: Please provide as much information as possible. Copy and paste console output and error messages including the _full_ traceback. Use [Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) to format text, code and logs. If necessary, include screenshots for visual elements only. Providing detailed information will help us resolve the issue more efficiently.
+      placeholder: |
+        💡 ProTip! Include as much information as possible (logs, tracebacks, screenshots, etc.) to receive the most helpful response.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Environment
+      description: Please provide your system information to help us diagnose the problem.
+      placeholder: |
+        Please include:
+        - Browser and version (e.g., Chrome 125, Safari 17)
+        - OS (e.g., Ubuntu 20.04, macOS 13.5, Windows 11, iOS 17)
+        - Page URL where the problem occurs
+        - Any relevant environment details
+
+        Example:
+        ```
+        Browser: Chrome 125
+        OS: macOS-13.5.2
+        Page: https://hub.ultralytics.com/models
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Minimal Reproducible Example
+      description: >
+        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example/).
+      placeholder: |
+        Steps to reproduce the problem in the web app, or a code snippet if using the API:
+
+        1. Go to ...
+        2. Click on ...
+        3. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional
+      description: Anything else you would like to share?
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: >
+        (Optional) We encourage you to submit a [Pull Request](https://github.com/ultralytics/hub/pulls) (PR) to help improve Ultralytics software for everyone, especially if you have a good understanding of how to implement a fix or feature.
+        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started.
+      options:
+        - label: Yes I'd like to help by submitting a PR!

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,6 +11,8 @@ body:
       value: |
         Thank you for submitting an Ultralytics 🐛 Bug Report!
 
+        Ultralytics HUB was retired on 2026-07-31; this repository is kept for historical reference. For active support and bugs with the Ultralytics Platform, see the [Platform API reference](https://platform.ultralytics.com/api/docs) and open issues at [ultralytics/sdk](https://github.com/ultralytics/sdk/issues). Use this form only for issues with the historical HUB repository or its redirect content.
+
   - type: checkboxes
     attributes:
       label: Search before asking

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 🚀 Ultralytics Platform
     url: https://platform.ultralytics.com/
@@ -14,3 +14,6 @@ contact_links:
   - name: 🎧 Discord
     url: https://ultralytics.com/discord
     about: Ask on Ultralytics Discord
+  - name: ⌨️ Reddit
+    url: https://reddit.com/r/ultralytics
+    about: Ask on Ultralytics Subreddit

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,6 +8,9 @@ contact_links:
   - name: 📄 Platform Docs
     url: https://docs.ultralytics.com/platform/
     about: Learn how to upload, annotate, train, export, and deploy with Platform
+  - name: 🐛 Platform SDK Issues
+    url: https://github.com/ultralytics/sdk/issues
+    about: Report bugs and request features for the Ultralytics Platform SDKs
   - name: 💬 Forum
     url: https://community.ultralytics.com/
     about: Ask on Ultralytics Community Forum

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -11,6 +11,8 @@ body:
       value: |
         Thank you for submitting an Ultralytics 🚀 Feature Request!
 
+        Ultralytics HUB was retired on 2026-07-31; this repository is kept for historical reference. For active support and bugs with the Ultralytics Platform, see the [Platform API reference](https://platform.ultralytics.com/api/docs) and open issues at [ultralytics/sdk](https://github.com/ultralytics/sdk/issues). Use this form only for issues with the historical HUB repository or its redirect content.
+
   - type: checkboxes
     attributes:
       label: Search before asking

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,53 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+name: 🚀 Feature Request
+description: Suggest an Ultralytics HUB idea
+# title: " "
+labels: [enhancement]
+type: "feature"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting an Ultralytics 🚀 Feature Request!
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please search the [Platform docs](https://docs.ultralytics.com/platform/) and [issues](https://github.com/ultralytics/hub/issues) to see if a similar feature request already exists.
+      options:
+        - label: >
+            I have searched the Ultralytics [issues](https://github.com/ultralytics/hub/issues) and found no similar feature requests.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: A short description of your feature.
+      placeholder: |
+        What new feature would you like to see in Ultralytics HUB?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Use case
+      description: |
+        Describe the use case of your feature request. It will help us understand and prioritize the feature request.
+      placeholder: |
+        How would this feature be used, and who would use it?
+
+  - type: textarea
+    attributes:
+      label: Additional
+      description: Anything else you would like to share?
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: >
+        (Optional) We encourage you to submit a [Pull Request](https://github.com/ultralytics/hub/pulls) (PR) to help improve Ultralytics software for everyone, especially if you have a good understanding of how to implement a fix or feature.
+        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started.
+      options:
+        - label: Yes I'd like to help by submitting a PR!

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,35 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+name: ❓ Question
+description: Ask an Ultralytics HUB question
+# title: " "
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for asking an Ultralytics ❓ Question!
+
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please search the [Platform docs](https://docs.ultralytics.com/platform/), [issues](https://github.com/ultralytics/hub/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) to see if a similar question already exists.
+      options:
+        - label: >
+            I have searched the Ultralytics [issues](https://github.com/ultralytics/hub/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) and found no similar questions.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Question
+      description: What is your question? Please provide as much information as possible. Include detailed code examples to reproduce the problem and describe the context in which the issue occurs. Format your text and code using [Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for clarity and readability. Following these guidelines will help us assist you more effectively.
+      placeholder: |
+        💡 ProTip! Include as much information as possible (logs, tracebacks, screenshots etc.) to receive the most helpful response.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional
+      description: Anything else you would like to share?

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -10,6 +10,8 @@ body:
       value: |
         Thank you for asking an Ultralytics ❓ Question!
 
+        Ultralytics HUB was retired on 2026-07-31; this repository is kept for historical reference. For active support and bugs with the Ultralytics Platform, see the [Platform API reference](https://platform.ultralytics.com/api/docs) and open issues at [ultralytics/sdk](https://github.com/ultralytics/sdk/issues). Use this form only for issues with the historical HUB repository or its redirect content.
+
   - type: checkboxes
     attributes:
       label: Search before asking

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,8 @@
 name: Ultralytics Actions
 
 on:
+  issues:
+    types: [opened]
   pull_request:
     branches: [main]
     types: [opened, closed, synchronize, review_requested]
@@ -13,6 +15,7 @@ on:
 permissions:
   contents: write # Modify code in PRs
   pull-requests: write # Add comments and labels to PRs
+  issues: write # Add comments and labels to issues
 
 jobs:
   actions:


### PR DESCRIPTION
- Add the `issues: opened` trigger and `issues: write` permission to `format.yml` so Ultralytics Actions labels new issues, matching the org standard.
- Add bug-report, feature-request and question issue templates modeled on the org standard, tailored to the HUB web app, and enable blank issues in `config.yml`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Standardized the repository’s issue intake and automation by adding HUB-specific issue templates, enabling blank issues, and allowing the Actions workflow to process newly opened issues.

### 📊 Key Changes

- Added bug report, feature request, and question forms with predefined labels and HUB-specific fields.
- Updated the forms to direct active Platform issues to the Platform documentation and `ultralytics/sdk`.
- Enabled blank issue submissions and added Platform SDK, Reddit, Forum, and Discord contact links.
- Updated `format.yml` to trigger on newly opened issues and grant `issues: write` permission for issue comments and labels.

### 🎯 Purpose & Impact

- New issue authors receive structured forms for common request types, while maintainers can use the existing automated actions on opened issues.
- Users can still submit unstructured issues and have additional support destinations available through the issue chooser.