### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the [Platform docs](https://docs.ultralytics.com/platform/) and [issues](https://github.com/ultralytics/hub/issues) to see if a similar bug report already exists.
+        Please search the [Platform docs](https://docs.ultralytics.com/platform) and [issues](https://github.com/ultralytics/hub/issues) to see if a similar bug report already exists.
       options:
         - label: >
             I have searched the Ultralytics [issues](https://github.com/ultralytics/hub/issues) and found no similar bug report.
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Minimal Reproducible Example
       description: >
-        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example/).
+        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example).
       placeholder: |
         Steps to reproduce the problem in the web app, or a code snippet if using the API:
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,16 +3,16 @@
 blank_issues_enabled: true
 contact_links:
   - name: 🚀 Ultralytics Platform
-    url: https://platform.ultralytics.com/
+    url: https://platform.ultralytics.com
     about: Start all new computer vision work on Ultralytics Platform
   - name: 📄 Platform Docs
-    url: https://docs.ultralytics.com/platform/
+    url: https://docs.ultralytics.com/platform
     about: Learn how to upload, annotate, train, export, and deploy with Platform
   - name: 🐛 Platform SDK Issues
     url: https://github.com/ultralytics/sdk/issues
     about: Report bugs and request features for the Ultralytics Platform SDKs
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the [Platform docs](https://docs.ultralytics.com/platform/) and [issues](https://github.com/ultralytics/hub/issues) to see if a similar feature request already exists.
+        Please search the [Platform docs](https://docs.ultralytics.com/platform) and [issues](https://github.com/ultralytics/hub/issues) to see if a similar feature request already exists.
       options:
         - label: >
             I have searched the Ultralytics [issues](https://github.com/ultralytics/hub/issues) and found no similar feature requests.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please search the [Platform docs](https://docs.ultralytics.com/platform/), [issues](https://github.com/ultralytics/hub/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) to see if a similar question already exists.
+        Please search the [Platform docs](https://docs.ultralytics.com/platform), [issues](https://github.com/ultralytics/hub/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) to see if a similar question already exists.
       options:
         - label: >
             I have searched the Ultralytics [issues](https://github.com/ultralytics/hub/issues) and [discussions](https://github.com/orgs/ultralytics/discussions) and found no similar questions.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Open Ultralytics Platform](https://img.shields.io/badge/Open-Ultralytics_Platform-111F68?logo=ultralytics&logoColor=white)](https://platform.ultralytics.com)
 [![Platform Docs](https://img.shields.io/badge/Read-Platform_Docs-00AEEF?logo=readthedocs&logoColor=white)](https://docs.ultralytics.com/platform)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
 
 </div>
 
@@ -59,7 +59,7 @@ Platform is the direct replacement for HUB—and a major upgrade. Create your wo
 
 ## 💬 Help and Community
 
-For current product help and feedback, use the **Help** page inside Platform, explore the [Platform documentation](https://docs.ultralytics.com/platform), or join the [Ultralytics community](https://community.ultralytics.com/). This repository remains available as a historical reference for HUB.
+For current product help and feedback, use the **Help** page inside Platform, explore the [Platform documentation](https://docs.ultralytics.com/platform), or join the [Ultralytics community](https://community.ultralytics.com). This repository remains available as a historical reference for HUB.
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,7 +58,7 @@ Platform 是 HUB 的直接替代产品，也是一次重大升级。立即创建
 
 ## 💬 帮助与社区
 
-如需当前产品帮助或提交反馈，请使用 Platform 内的 **Help** 页面、浏览 [Platform 文档](https://docs.ultralytics.com/zh/platform)，或加入 [Ultralytics 社区](https://community.ultralytics.com/)。本仓库仅作为 HUB 的历史参考保留。
+如需当前产品帮助或提交反馈，请使用 Platform 内的 **Help** 页面、浏览 [Platform 文档](https://docs.ultralytics.com/zh/platform)，或加入 [Ultralytics 社区](https://community.ultralytics.com)。本仓库仅作为 HUB 的历史参考保留。
 
 [![Ultralytics 开源贡献者](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 

--- a/example_datasets/coco8-human/README.md
+++ b/example_datasets/coco8-human/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Ultralytics coco8-human Dataset
 
@@ -19,20 +19,20 @@ This dataset is fully compatible with the Ultralytics framework and integrates s
 
 Ultralytics HUB shut down on July 31, 2026, after the managed migration completed in Q2. Use [Ultralytics Platform](https://platform.ultralytics.com) for current dataset, training, export, and deployment workflows.
 
-For more information on datasets, model training, and best practices, explore the [Ultralytics documentation](https://docs.ultralytics.com/), learn about [data annotation and collection](https://docs.ultralytics.com/guides/data-collection-and-annotation), or discover [object detection solutions](https://www.ultralytics.com/solutions/ai-in-automotive). If you're interested in the latest trends in computer vision, check out the [Ultralytics blog](https://www.ultralytics.com/blog/a-guide-to-deep-dive-into-object-detection-in-2025).
+For more information on datasets, model training, and best practices, explore the [Ultralytics documentation](https://docs.ultralytics.com), learn about [data annotation and collection](https://docs.ultralytics.com/guides/data-collection-and-annotation), or discover [object detection solutions](https://www.ultralytics.com/solutions/computer-vision-in-automotive). If you're interested in the latest trends in computer vision, check out the [Ultralytics blog](https://www.ultralytics.com/blog/a-guide-to-deep-dive-into-object-detection-in-2025).
 
-Join the discussion and get support from the community at the [Ultralytics Community Forums](https://community.ultralytics.com/) or connect with other users on [Ultralytics Discord](https://discord.com/invite/ultralytics).
+Join the discussion and get support from the community at the [Ultralytics Community Forums](https://community.ultralytics.com) or connect with other users on [Ultralytics Discord](https://discord.com/invite/ultralytics).
 
 ## 📚 Resources
 
 Enhance your experience with COCO8-human and Ultralytics tools using these valuable resources:
 
 - [Ultralytics Platform Datasets](https://docs.ultralytics.com/platform/data/datasets): Step-by-step guide to uploading, analyzing, and preparing datasets like COCO8-human.
-- [Ultralytics Documentation](https://docs.ultralytics.com/): Comprehensive guides on model usage, best practices, and advanced features.
+- [Ultralytics Documentation](https://docs.ultralytics.com): Comprehensive guides on model usage, best practices, and advanced features.
 - [COCO Dataset Overview](https://docs.ultralytics.com/datasets/detect/coco): Learn more about the full COCO dataset and its applications in computer vision.
 - [Ultralytics Models](https://docs.ultralytics.com/models): Explore available YOLO models for object detection, segmentation, and more.
 - [Ultralytics Discord Community](https://discord.com/invite/ultralytics): Connect with users, developers, and the Ultralytics team for real-time discussions.
-- [Ultralytics Community Forums](https://community.ultralytics.com/): Share your projects, ask questions, and engage with the broader Ultralytics community.
+- [Ultralytics Community Forums](https://community.ultralytics.com): Share your projects, ask questions, and engage with the broader Ultralytics community.
 - [Ultralytics Tasks Overview](https://docs.ultralytics.com/tasks): Learn about supported computer vision tasks, including detection, segmentation, and more.
 - [Ultralytics Model Training Tips](https://docs.ultralytics.com/guides/model-training-tips): Best practices for efficient and effective model training.
 - [Ultralytics Model Evaluation Insights](https://docs.ultralytics.com/guides/model-evaluation-insights): Guidance on evaluating model performance and interpreting results.

--- a/example_datasets/coco8-pose/README.md
+++ b/example_datasets/coco8-pose/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Ultralytics COCO8-pose Dataset
 
@@ -23,11 +23,11 @@ Below are examples showcasing images from the COCO8-pose dataset, visualized in 
 Enhance your experience with COCO8-pose and Ultralytics tools using these valuable resources:
 
 - [Ultralytics Platform Datasets](https://docs.ultralytics.com/platform/data/datasets): Step-by-step guide to uploading, analyzing, and preparing datasets like COCO8-pose.
-- [Ultralytics Documentation](https://docs.ultralytics.com/): Comprehensive guides on model usage, best practices, and advanced features.
+- [Ultralytics Documentation](https://docs.ultralytics.com): Comprehensive guides on model usage, best practices, and advanced features.
 - [COCO Dataset Overview](https://docs.ultralytics.com/datasets/detect/coco): Learn more about the full COCO dataset and its applications in computer vision.
 - [Ultralytics Models](https://docs.ultralytics.com/models): Explore available YOLO models for object detection, segmentation, and more.
 - [Ultralytics Discord Community](https://discord.com/invite/ultralytics): Connect with users, developers, and the Ultralytics team for real-time discussions.
-- [Ultralytics Community Forums](https://community.ultralytics.com/): Share your projects, ask questions, and engage with the broader Ultralytics community.
+- [Ultralytics Community Forums](https://community.ultralytics.com): Share your projects, ask questions, and engage with the broader Ultralytics community.
 - [Ultralytics Tasks Overview](https://docs.ultralytics.com/tasks): Learn about supported computer vision tasks, including detection, segmentation, and more.
 - [Ultralytics Model Training Tips](https://docs.ultralytics.com/guides/model-training-tips): Best practices for efficient and effective model training.
 - [Ultralytics Model Evaluation Insights](https://docs.ultralytics.com/guides/model-evaluation-insights): Guidance on evaluating model performance and interpreting results.

--- a/example_datasets/coco8-seg/README.md
+++ b/example_datasets/coco8-seg/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Ultralytics COCO8-Seg Dataset
 
@@ -23,11 +23,11 @@ Below are sample images from the COCO8-Seg dataset, each with its corresponding 
 Enhance your experience with COCO8-seg and Ultralytics tools using these valuable resources:
 
 - [Ultralytics Platform Datasets](https://docs.ultralytics.com/platform/data/datasets): Step-by-step guide to uploading, analyzing, and preparing datasets like COCO8-seg.
-- [Ultralytics Documentation](https://docs.ultralytics.com/): Comprehensive guides on model usage, best practices, and advanced features.
+- [Ultralytics Documentation](https://docs.ultralytics.com): Comprehensive guides on model usage, best practices, and advanced features.
 - [COCO Dataset Overview](https://docs.ultralytics.com/datasets/detect/coco): Learn more about the full COCO dataset and its applications in computer vision.
 - [Ultralytics Models](https://docs.ultralytics.com/models): Explore available YOLO models for object detection, segmentation, and more.
 - [Ultralytics Discord Community](https://discord.com/invite/ultralytics): Connect with users, developers, and the Ultralytics team for real-time discussions.
-- [Ultralytics Community Forums](https://community.ultralytics.com/): Share your projects, ask questions, and engage with the broader Ultralytics community.
+- [Ultralytics Community Forums](https://community.ultralytics.com): Share your projects, ask questions, and engage with the broader Ultralytics community.
 - [Ultralytics Tasks Overview](https://docs.ultralytics.com/tasks): Learn about supported computer vision tasks, including detection, segmentation, and more.
 - [Ultralytics Model Training Tips](https://docs.ultralytics.com/guides/model-training-tips): Best practices for efficient and effective model training.
 - [Ultralytics Model Evaluation Insights](https://docs.ultralytics.com/guides/model-evaluation-insights): Guidance on evaluating model performance and interpreting results.

--- a/example_datasets/coco8/README.md
+++ b/example_datasets/coco8/README.md
@@ -1,10 +1,10 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Ultralytics COCO8 Dataset
 
 ## 🚀 Introduction
 
-The [Ultralytics COCO8 dataset](https://docs.ultralytics.com/datasets/detect/coco8) is a compact and versatile resource for [object detection](https://www.ultralytics.com/glossary/object-detection) tasks. It consists of the first 8 images from the popular [COCO train 2017 dataset](https://cocodataset.org/#home), split into 4 images for training and 4 for validation. This small dataset is ideal for **quick testing, debugging, and validating** your object detection pipelines within the [Ultralytics](https://www.ultralytics.com/) ecosystem.
+The [Ultralytics COCO8 dataset](https://docs.ultralytics.com/datasets/detect/coco8) is a compact and versatile resource for [object detection](https://www.ultralytics.com/glossary/object-detection) tasks. It consists of the first 8 images from the popular [COCO train 2017 dataset](https://cocodataset.org/#home), split into 4 images for training and 4 for validation. This small dataset is ideal for **quick testing, debugging, and validating** your object detection pipelines within the [Ultralytics](https://www.ultralytics.com) ecosystem.
 
 COCO8 is especially useful for verifying your setup before scaling up to [larger datasets](https://docs.ultralytics.com/datasets), making it a valuable **sanity check** for model training, data loading, and annotation workflows. Its manageable size ensures rapid iteration, whether you are experimenting with new detection strategies or validating data in [Ultralytics Platform](https://platform.ultralytics.com) with [Ultralytics YOLO](https://docs.ultralytics.com/models/yolo11). To get started with training on COCO8, follow the [Ultralytics Quickstart guide](https://docs.ultralytics.com/quickstart).
 
@@ -21,11 +21,11 @@ COCO8 features diverse scenes with multiple objects, providing a realistic testi
 Enhance your experience with COCO8 and Ultralytics tools using these valuable resources:
 
 - [Ultralytics Platform Datasets](https://docs.ultralytics.com/platform/data/datasets): Step-by-step guide to uploading, analyzing, and preparing datasets like COCO8.
-- [Ultralytics Documentation](https://docs.ultralytics.com/): Comprehensive guides on model usage, best practices, and advanced features.
+- [Ultralytics Documentation](https://docs.ultralytics.com): Comprehensive guides on model usage, best practices, and advanced features.
 - [COCO Dataset Overview](https://docs.ultralytics.com/datasets/detect/coco): Learn more about the full COCO dataset and its applications in computer vision.
 - [Ultralytics Models](https://docs.ultralytics.com/models): Explore available YOLO models for object detection, segmentation, and more.
 - [Ultralytics Discord Community](https://discord.com/invite/ultralytics): Connect with users, developers, and the Ultralytics team for real-time discussions.
-- [Ultralytics Community Forums](https://community.ultralytics.com/): Share your projects, ask questions, and engage with the broader Ultralytics community.
+- [Ultralytics Community Forums](https://community.ultralytics.com): Share your projects, ask questions, and engage with the broader Ultralytics community.
 - [Ultralytics Tasks Overview](https://docs.ultralytics.com/tasks): Learn about supported computer vision tasks, including detection, segmentation, and more.
 - [Ultralytics Model Training Tips](https://docs.ultralytics.com/guides/model-training-tips): Best practices for efficient and effective model training.
 - [Ultralytics Model Evaluation Insights](https://docs.ultralytics.com/guides/model-evaluation-insights): Guidance on evaluating model performance and interpreting results.

--- a/example_datasets/dota8/README.md
+++ b/example_datasets/dota8/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Ultralytics DOTA8 Dataset
 
@@ -17,11 +17,11 @@ Ultralytics HUB shut down on July 31, 2026, after the managed migration complete
 Enhance your experience with DOTA8 and Ultralytics tools using these valuable resources:
 
 - [Ultralytics Platform Datasets](https://docs.ultralytics.com/platform/data/datasets): Step-by-step guide to uploading, analyzing, and preparing datasets like DOTA8.
-- [Ultralytics Documentation](https://docs.ultralytics.com/): Comprehensive guides on model usage, best practices, and advanced features.
+- [Ultralytics Documentation](https://docs.ultralytics.com): Comprehensive guides on model usage, best practices, and advanced features.
 - [COCO Dataset Overview](https://docs.ultralytics.com/datasets/detect/coco): Learn more about the full COCO dataset and its applications in computer vision.
 - [Ultralytics Models](https://docs.ultralytics.com/models): Explore available YOLO models for object detection, segmentation, and more.
 - [Ultralytics Discord Community](https://discord.com/invite/ultralytics): Connect with users, developers, and the Ultralytics team for real-time discussions.
-- [Ultralytics Community Forums](https://community.ultralytics.com/): Share your projects, ask questions, and engage with the broader Ultralytics community.
+- [Ultralytics Community Forums](https://community.ultralytics.com): Share your projects, ask questions, and engage with the broader Ultralytics community.
 - [Ultralytics Tasks Overview](https://docs.ultralytics.com/tasks): Learn about supported computer vision tasks, including detection, segmentation, and more.
 - [Ultralytics Model Training Tips](https://docs.ultralytics.com/guides/model-training-tips): Best practices for efficient and effective model training.
 - [Ultralytics Model Evaluation Insights](https://docs.ultralytics.com/guides/model-evaluation-insights): Guidance on evaluating model performance and interpreting results.

--- a/example_datasets/dota8/dota8.yaml
+++ b/example_datasets/dota8/dota8.yaml
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # DOTA8 dataset 8 images from split DOTAv1 dataset by Ultralytics
-# Documentation: https://docs.ultralytics.com/datasets/obb/dota8/
+# Documentation: https://docs.ultralytics.com/datasets/obb/dota8
 # Example usage: yolo train model=yolov8n-obb.pt data=dota8.yaml
 # parent
 # ├── ultralytics


### PR DESCRIPTION
Normalizes Ultralytics link hygiene across the historical HUB repository: no URL on `ultralytics.com` or any `*.ultralytics.com` subdomain keeps a terminating path slash, and links that permanently moved now point at their current destination.

## Trailing slashes (29 across 12 files)

Removed the terminating path slash only — path separators, `%2F`-encoded URLs, and fragments/queries are untouched. Applied with a regex fixer validated against 17 positive and 19 negative cases before it ran (subdomains, protocol-relative, bare-host, fragment/query, sentence-final punctuation, markdown/HTML/backtick delimiters; negatives: `github.com/ultralytics/...`, emails, `notultralytics.com`, `https%3A%2F%2F` badge params, `{placeholder}` templates, `/...` ellipsis, and `.../ultralytics.com/...` inside another host's path).

Representative changes:

- `https://docs.ultralytics.com/platform/` -> `https://docs.ultralytics.com/platform` (four issue templates)
- `https://platform.ultralytics.com/` and `https://community.ultralytics.com/` contact links in `config.yml`
- `<a href="https://www.ultralytics.com/">` logo anchors in all five `example_datasets/*/README.md`
- `https://docs.ultralytics.com/datasets/obb/dota8/` in `dota8.yaml`
- `https://docs.ultralytics.com/help/minimum-reproducible-example/` in `bug-report.yml`

Post-run verification re-scanned every tracked text file: zero Ultralytics URLs retain a terminating slash.

## Redirect refresh (1 accepted, 0 rejected of the proposals)

- `https://www.ultralytics.com/solutions/ai-in-automotive` -> `https://www.ultralytics.com/solutions/computer-vision-in-automotive` — verified 308 permanent, destination 200, same host, no locale/tracking/auth params.

Deliberately left unchanged after review:

- `https://ultralytics.com/license` (AGENTS.md) — Ultralytics Actions owns this header string; rewriting it to `www.` would desync the tool from its own output.
- `https://ultralytics.com/discord` (`config.yml`) — vanity shortlink whose target is an expiring invite.
- `https://reddit.com/r/ultralytics` — canonicalizes to `https://www.reddit.com/r/ultralytics/`, which re-adds a trailing slash.
- `https://github.com/ultralytics/assets/raw/main/social/*.png` — `/raw/` image srcs are a durable GitHub alias; resolving them to `raw.githubusercontent.com` changes the role the URL plays.
- shields.io badge URLs — the `server=https%3A%2F%2Fcommunity.ultralytics.com` parameter and the Chinese badge labels must stay byte-identical; only percent-encoding differs on resolution.
- lychee release asset in `links.yml` — resolves to an expiring signed `release-assets.githubusercontent.com` URL.

## Dead links flagged (not changed, need a human)

Both are pre-existing and unrelated to this diff:

1. `https://docs.ultralytics.com/datasets/human` in `example_datasets/coco8-human/coco8-human.yaml` returns 404. No direct successor exists (`/datasets/detect/coco8-human` and `/tasks/human` are also 404); only `/datasets` resolves, which would be an index collapse, so the link is left as-is for a correct target.
2. `Page: https://hub.ultralytics.com/models` in `bug-report.yml` returns 404 and forwards to `https://platform.ultralytics.com/models`, which is itself 404 for anonymous requests. It is a placeholder example inside the historical HUB bug-report form, so the HUB-specific deep link is left in place rather than rewritten to a Platform route that does not serve.

## Validation

- `npx prettier@3.8.5 --check --print-width 120 "**/*.{md,yml,yaml,json}"` — clean.
- All eight `.yml`/`.yaml` files re-parsed successfully.
- Serial (non-parallel) status check of all 100 URLs in the repository: only the two dead links above.
- Full diff reviewed line by line: every hunk is URL text only, no prose or structural edits.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Normalized Ultralytics URLs across repository documentation and configuration by removing trailing slashes and updating one permanently redirected automotive solutions link.

### 📊 Key Changes
- Removed trailing slashes from Ultralytics URLs in issue templates, issue configuration, README files, example dataset documentation, and `dota8.yaml`.
- Updated `https://www.ultralytics.com/solutions/ai-in-automotive` to [`https://www.ultralytics.com/solutions/computer-vision-in-automotive`](https://www.ultralytics.com/solutions/computer-vision-in-automotive).
- Preserved URLs that require their existing form, including the `ultralytics.com/license` header, Discord vanity link, Reddit URL, GitHub raw asset URLs, badge parameters, and the signed release asset link.
- Left two pre-existing dead links unchanged: the COCO8-human documentation URL and the historical HUB models placeholder.

### 🎯 Purpose & Impact
- Ultralytics links now use consistent trailing-slash formatting, and the automotive solutions link points to its current permanent destination.
- No functional code or repository structure changed; the remaining dead links require separate manual target decisions.